### PR TITLE
Document free-threaded build limitation (#3)

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,6 +18,7 @@ Algebraic effects for Python — deep, stateful, multi-shot handlers via greenle
 - CPython 3.12, 3.13, or 3.14 (CPython-specific C extension)
 - greenlet >= 3.3.2
 - Linux / macOS (Windows not yet supported — see [#1](https://github.com/hnmr293/aleff/issues/1))
+- **Note**: Free-threaded (no-GIL) builds are not supported — see [#3](https://github.com/hnmr293/aleff/issues/3)
 
 ## Installation
 


### PR DESCRIPTION
## Summary

Document that free-threaded (no-GIL) Python builds are not supported. Refs #3.

Investigation found that greenlet 3.3.2 re-enables the GIL on free-threaded builds, making free-threading support not feasible at this time. See issue comment for full details.

## Changes

- Add note to README Requirements section linking to #3

## Commits

- `7459b5e` document free-threaded build limitation in README (#3)