### PR TITLE
replace GreenletExit with EffectAborted to prevent leaking internals (#8)

### DIFF
--- a/src/aleff/_multishot/v1/effects.py
+++ b/src/aleff/_multishot/v1/effects.py
@@ -42,6 +42,16 @@ def effect[**P, R](*args: str | Callable[..., Any]) -> Effect[..., Any] | Callab
     return decorator
 
 
+class EffectAborted(BaseException):
+    """Raised internally to abort a computation without leaking GreenletExit."""
+
+    pass
+
+
+ABORT = object()
+"""Sentinel value switched into a caller greenlet to trigger EffectAborted."""
+
+
 def _make_effect(name: str) -> Effect[..., Any]:
     """Create a new effect as a plain Python function.
 
@@ -61,7 +71,10 @@ def _make_effect(name: str) -> Effect[..., Any]:
         handler_gl = gl.getcurrent().parent
         if handler_gl is None:
             raise EffectNotHandledError(eff)
-        return handler_gl.switch(EffectContext(eff, args, kwargs))
+        result = handler_gl.switch(EffectContext(eff, args, kwargs))
+        if result is ABORT:
+            raise EffectAborted()
+        return result
 
     perform.name = name  # pyright: ignore[reportFunctionMemberAccess]
     eff = cast(Effect[..., Any], perform)

--- a/src/aleff/_multishot/v1/handlers.py
+++ b/src/aleff/_multishot/v1/handlers.py
@@ -15,7 +15,7 @@ from .intf import (
     Handler,
     AsyncHandler,
 )
-from .effects import EffectContext
+from .effects import EffectContext, ABORT, EffectAborted
 from .misc import debug, eff_str
 from ._aleff import FrameSnapshot, restore_continuation, snapshot_from_frame
 
@@ -255,12 +255,35 @@ def _drive[V](caller_gl: Any, value: V | EffectContext[..., Any]) -> V:
         # resume not called in the handler
         # discard the result
         debug(f"||< **abort** perform {eff_str(d.effect)} = {v!r}")
-        caller_gl.throw(gl.GreenletExit)
+        _abort_caller(caller_gl)
 
     debug(f"||< perform {eff_str(d.effect)} = {v!r}")
 
     debug("||< @main")
     return v
+
+
+def _abort_caller(caller_gl: Any) -> None:
+    """Abort a caller greenlet without exposing GreenletExit.
+
+    Sends the ``ABORT`` sentinel to the caller.  The effect invocation
+    function recognises it and raises ``EffectAborted`` (a
+    ``BaseException`` subclass), which propagates through ``finally``
+    blocks but is not caught by ``except Exception``.
+    """
+
+    try:
+        abort_v = caller_gl.switch(ABORT)
+    except EffectAborted:
+        return
+    while not caller_gl.dead:
+        if isinstance(abort_v, EffectContext):
+            try:
+                abort_v = caller_gl.switch(ABORT)
+            except EffectAborted:
+                return
+        else:
+            break
 
 
 class _AwaitRequest[V]:
@@ -419,7 +442,7 @@ async def _drive_async[V](
         # resume not called in the handler
         # discard the result
         debug(f"||< **abort** perform {eff_str(d.effect)} = {v!r}")
-        caller_gl.throw(gl.GreenletExit)
+        _abort_caller(caller_gl)
 
     debug(f"||< perform {eff_str(d.effect)} = {v!r}")
 

--- a/src/aleff/_oneshot/v8_1/effects.py
+++ b/src/aleff/_oneshot/v8_1/effects.py
@@ -76,6 +76,16 @@ class EffectContext[**P, R]:
         return f"({self.effect} | args={self.args!r}, kwargs={self.kwargs!r})"
 
 
+class EffectAborted(BaseException):
+    """Raised internally to abort a computation without leaking GreenletExit."""
+
+    pass
+
+
+ABORT = object()
+"""Sentinel value switched into a caller greenlet to trigger EffectAborted."""
+
+
 class _Effect[**P, R](Effect[P, R]):
     def __init__(self, name: str):
         self._name = name
@@ -91,7 +101,10 @@ class _Effect[**P, R](Effect[P, R]):
         handler_gl = gl.getcurrent().parent
         if handler_gl is None:
             raise EffectNotHandledError(self)
-        return handler_gl.switch(EffectContext(self, args, kwargs))
+        result = handler_gl.switch(EffectContext(self, args, kwargs))
+        if result is ABORT:
+            raise EffectAborted()
+        return result
 
     def __str__(self) -> str:
         return f"<effect {self.name}>"

--- a/src/aleff/_oneshot/v8_1/handlers.py
+++ b/src/aleff/_oneshot/v8_1/handlers.py
@@ -15,7 +15,7 @@ from .intf import (
     Handler,
     AsyncHandler,
 )
-from .effects import EffectContext
+from .effects import EffectContext, ABORT, EffectAborted
 from .misc import debug
 
 
@@ -201,15 +201,42 @@ def _drive[V](caller_gl: Any, value: V | EffectContext[..., Any]) -> V:
     v = d.fn(resume, *d.args, **d.kwargs)
 
     if not caller_gl.dead:
-        # resume not called in the handler
-        # discard the result
+        # resume not called in the handler — abort the computation.
+        # Send ABORT sentinel so that _Effect.__call__ raises
+        # EffectAborted instead of exposing GreenletExit.
         debug(f"||< **abort** perform {d.effect} = {v!r}")
-        caller_gl.throw(gl.GreenletExit)
+        _abort_caller(caller_gl)
 
     debug(f"||< perform {d.effect} = {v!r}")
 
     debug("||< @main")
     return v
+
+
+def _abort_caller(caller_gl: Any) -> None:
+    """Abort a caller greenlet without exposing GreenletExit.
+
+    Sends the ``ABORT`` sentinel to the caller.  ``_Effect.__call__``
+    recognises it and raises ``EffectAborted`` (a ``BaseException``
+    subclass), which propagates through ``finally`` blocks but is not
+    caught by ``except Exception``.
+
+    If the caller catches ``EffectAborted`` and performs another effect,
+    the loop sends ``ABORT`` again until the greenlet dies.
+    """
+
+    try:
+        abort_v = caller_gl.switch(ABORT)
+    except EffectAborted:
+        return  # caller died from the abort — expected
+    while not caller_gl.dead:
+        if isinstance(abort_v, EffectContext):
+            try:
+                abort_v = caller_gl.switch(ABORT)
+            except EffectAborted:
+                return
+        else:
+            break
 
 
 class _AwaitRequest:
@@ -340,7 +367,7 @@ async def _drive_async[V](
         # resume not called in the handler
         # discard the result
         debug(f"||< **abort** perform {d.effect} = {v!r}")
-        caller_gl.throw(gl.GreenletExit)
+        _abort_caller(caller_gl)
 
     debug(f"||< perform {d.effect} = {v!r}")
 

--- a/tests/test_exception.py
+++ b/tests/test_exception.py
@@ -1,0 +1,489 @@
+"""Tests for exception integration with effect handlers (Issue #8).
+
+Defines and verifies the semantics for how exceptions interact with
+effect handlers in all supported scenarios.
+"""
+
+import asyncio  # pyright: ignore[reportUnusedImport]
+
+import pytest
+import pytest_asyncio  # pyright: ignore[reportUnusedImport]
+
+from aleff import (
+    effect,
+    Effect,
+    Resume,
+    ResumeAsync,
+    Handler,
+    AsyncHandler,
+    create_handler,
+    create_async_handler,
+    EffectNotHandledError,
+)
+
+
+# ---------------------------------------------------------------------------
+# Exception in computation
+# ---------------------------------------------------------------------------
+
+
+class TestComputationException:
+    def test_exception_before_effect(self):
+        """Exception raised before any effect is performed."""
+        e: Effect[[], str] = effect("e")
+        h: Handler[str] = create_handler(e)
+
+        @h.on(e)
+        def _handle(k: Resume[str, str]):
+            return k("val")
+
+        with pytest.raises(RuntimeError, match="before effect"):
+            h(lambda: (_ for _ in ()).throw(RuntimeError("before effect")))
+
+    def test_exception_after_resume(self):
+        """Exception raised in computation after effect is resumed."""
+        e: Effect[[], int] = effect("e")
+        h: Handler[int] = create_handler(e)
+
+        @h.on(e)
+        def _handle(k: Resume[int, int]):
+            return k(42)
+
+        def caller() -> int:
+            val = e()
+            raise RuntimeError(f"after resume: {val}")
+
+        with pytest.raises(RuntimeError, match="after resume: 42"):
+            h(caller)
+
+    def test_handler_catches_computation_exception_via_resume(self):
+        """Handler can catch exceptions from computation via k()."""
+        e: Effect[[], int] = effect("e")
+        h: Handler[int] = create_handler(e)
+
+        @h.on(e)
+        def _handle(k: Resume[int, int]):
+            try:
+                return k(42)
+            except RuntimeError:
+                return -1
+
+        def caller() -> int:
+            e()
+            raise RuntimeError("computation error")
+
+        result = h(caller)
+        assert result == -1
+
+
+# ---------------------------------------------------------------------------
+# Exception in handler function
+# ---------------------------------------------------------------------------
+
+
+class TestHandlerException:
+    def test_handler_exception_before_resume(self):
+        """Exception in handler fn before calling k()."""
+        e: Effect[[], str] = effect("e")
+        h: Handler[str] = create_handler(e)
+
+        @h.on(e)
+        def _handle(k: Resume[str, str]):
+            raise ValueError("handler error")
+
+        with pytest.raises(ValueError, match="handler error"):
+            h(lambda: e())
+
+    def test_handler_exception_after_resume(self):
+        """Exception in handler fn after k() returns."""
+        e: Effect[[], int] = effect("e")
+        h: Handler[int] = create_handler(e)
+
+        @h.on(e)
+        def _handle(k: Resume[int, int]):
+            result = k(42)
+            raise ValueError(f"post-resume: {result}")
+
+        with pytest.raises(ValueError, match="post-resume: 42"):
+            h(lambda: e())
+
+    def test_handler_exception_wins_over_computation(self):
+        """When both handler and computation raise, handler's exception propagates."""
+        e: Effect[[], int] = effect("e")
+        h: Handler[int] = create_handler(e)
+
+        @h.on(e)
+        def _handle(k: Resume[int, int]):
+            try:
+                return k(42)
+            except RuntimeError:
+                pass
+            raise ValueError("handler error")
+
+        def caller() -> int:
+            e()
+            raise RuntimeError("computation error")
+
+        with pytest.raises(ValueError, match="handler error"):
+            h(caller)
+
+
+# ---------------------------------------------------------------------------
+# Abort (handler doesn't call resume) — GreenletExit must not leak
+# ---------------------------------------------------------------------------
+
+
+class TestAbortNoGreenletExitLeak:
+    def test_abort_basic(self):
+        """Handler returns without calling k() — computation is aborted."""
+        e: Effect[[], int] = effect("e")
+        h: Handler[int] = create_handler(e)
+
+        @h.on(e)
+        def _handle(k: Resume[int, int]):
+            return 99
+
+        result = h(lambda: e())
+        assert result == 99
+
+    def test_abort_does_not_leak_greenlet_exit(self):
+        """Abort must NOT expose GreenletExit to user code."""
+        import greenlet as gl
+
+        e: Effect[[], int] = effect("e")
+        h: Handler[int] = create_handler(e)
+
+        @h.on(e)
+        def _handle(k: Resume[int, int]):
+            return 99
+
+        caught_types: list[type] = []
+
+        def caller() -> int:
+            try:
+                return e()
+            except BaseException as ex:
+                caught_types.append(type(ex))
+                raise
+
+        result = h(caller)
+        assert result == 99
+        # GreenletExit must NOT appear in caught exceptions
+        assert gl.GreenletExit not in caught_types
+
+    def test_abort_finally_runs(self):
+        """Abort should still run finally blocks in the computation."""
+        e: Effect[[], int] = effect("e")
+        h: Handler[int] = create_handler(e)
+
+        @h.on(e)
+        def _handle(k: Resume[int, int]):
+            return 99
+
+        finally_ran = False
+
+        def caller() -> int:
+            nonlocal finally_ran
+            try:
+                return e()
+            finally:
+                finally_ran = True
+
+        result = h(caller)
+        assert result == 99
+        assert finally_ran
+
+    def test_abort_except_exception_does_not_catch(self):
+        """Abort should NOT be caught by 'except Exception'."""
+        e: Effect[[], int] = effect("e")
+        h: Handler[int] = create_handler(e)
+
+        @h.on(e)
+        def _handle(k: Resume[int, int]):
+            return 99
+
+        caught = False
+
+        def caller() -> int:
+            nonlocal caught
+            try:
+                return e()
+            except Exception:
+                caught = True
+                return -1
+
+        result = h(caller)
+        assert result == 99
+        assert not caught
+
+    def test_abort_caller_catches_and_performs_another_effect(self):
+        """If caller catches abort and performs another effect, abort persists."""
+        e1: Effect[[], int] = effect("e1")
+        e2: Effect[[], int] = effect("e2")
+        h: Handler[int] = create_handler(e1, e2)
+
+        @h.on(e1)
+        def _handle_e1(k: Resume[int, int]):
+            return 99  # abort
+
+        @h.on(e2)
+        def _handle_e2(k: Resume[int, int]):
+            return k(50)
+
+        attempts = 0
+
+        def caller() -> int:
+            nonlocal attempts
+            try:
+                return e1()
+            except BaseException:
+                attempts += 1
+                return e2()  # try another effect after catching abort
+
+        result = h(caller)
+        assert result == 99
+
+
+# ---------------------------------------------------------------------------
+# Nested handler exception propagation
+# ---------------------------------------------------------------------------
+
+
+class TestNestedException:
+    def test_exception_propagates_through_nested_handlers(self):
+        """Exception in innermost computation propagates through all handlers."""
+        e1: Effect[[], int] = effect("e1")
+        e2: Effect[[], int] = effect("e2")
+
+        h1: Handler[int] = create_handler(e1)
+        h2: Handler[int] = create_handler(e2)
+
+        @h1.on(e1)
+        def _h1(k: Resume[int, int]):
+            return k(10)
+
+        @h2.on(e2)
+        def _h2(k: Resume[int, int]):
+            return k(20)
+
+        def caller() -> int:
+            e1()
+            raise RuntimeError("nested error")
+
+        with pytest.raises(RuntimeError, match="nested error"):
+            h1(lambda: h2(caller))
+
+    def test_inner_handler_catches_exception(self):
+        """Inner handler can catch and recover from computation exception."""
+        e1: Effect[[], int] = effect("e1")
+        e2: Effect[[], int] = effect("e2")
+
+        h1: Handler[int] = create_handler(e1)
+        h2: Handler[int] = create_handler(e2)
+
+        @h1.on(e1)
+        def _h1(k: Resume[int, int]):
+            return k(10)
+
+        @h2.on(e2)
+        def _h2(k: Resume[int, int]):
+            try:
+                return k(20)
+            except RuntimeError:
+                return -1
+
+        def caller() -> int:
+            e1()
+            e2()
+            raise RuntimeError("error")
+
+        result = h1(lambda: h2(caller))
+        assert result == -1
+
+
+# ---------------------------------------------------------------------------
+# Multi-shot + exceptions
+# ---------------------------------------------------------------------------
+
+
+class TestMultiShotException:
+    def test_exception_in_one_shot_handler_continues(self):
+        """Multi-shot: exception in one shot, handler catches and continues."""
+        e: Effect[[], int] = effect("e")
+        h: Handler[list[int]] = create_handler(e)
+
+        @h.on(e)
+        def _handle(k: Resume[int, list[int]]):
+            results: list[list[int]] = []
+            for val in [1, 2, 3]:
+                try:
+                    results.append(k(val))
+                except ValueError:
+                    results.append([-1])
+            return [x for r in results for x in r]
+
+        def caller() -> list[int]:
+            val = e()
+            if val == 2:
+                raise ValueError("bad")
+            return [val * 10]
+
+        result = h(caller)
+        assert result == [10, -1, 30]
+
+    def test_exception_in_handler_after_multishot(self):
+        """Exception in handler fn after multiple k() calls."""
+        e: Effect[[], int] = effect("e")
+        h: Handler[list[int]] = create_handler(e)
+
+        @h.on(e)
+        def _handle(k: Resume[int, list[int]]):
+            k(1)
+            k(2)
+            raise ValueError("after multishot")
+
+        def caller() -> list[int]:
+            return [e() * 10]
+
+        with pytest.raises(ValueError, match="after multishot"):
+            h(caller)
+
+
+# ---------------------------------------------------------------------------
+# Async exception integration
+# ---------------------------------------------------------------------------
+
+
+class TestAsyncException:
+    @pytest.mark.asyncio
+    async def test_async_handler_exception_after_resume(self):
+        """Async handler fn raises after await k()."""
+        e: Effect[[], int] = effect("e")
+        h: AsyncHandler[int] = create_async_handler(e)
+
+        @h.on(e)
+        async def _handle(k: ResumeAsync[int, int]):
+            result = await k(42)
+            raise ValueError(f"async post-resume: {result}")
+
+        with pytest.raises(ValueError, match="async post-resume: 42"):
+            await h(lambda: e())
+
+    @pytest.mark.asyncio
+    async def test_async_handler_catches_computation_exception(self):
+        """Async handler catches exception from computation via k()."""
+        e: Effect[[], int] = effect("e")
+        h: AsyncHandler[int] = create_async_handler(e)
+
+        @h.on(e)
+        async def _handle(k: ResumeAsync[int, int]):
+            try:
+                return await k(42)
+            except RuntimeError:
+                return -1
+
+        def caller() -> int:
+            e()
+            raise RuntimeError("computation error")
+
+        result = await h(caller)
+        assert result == -1
+
+    @pytest.mark.asyncio
+    async def test_async_abort_does_not_leak_greenlet_exit(self):
+        """Async abort must NOT expose GreenletExit to user code."""
+        import greenlet as gl
+
+        e: Effect[[], int] = effect("e")
+        h: AsyncHandler[int] = create_async_handler(e)
+
+        @h.on(e)
+        async def _handle(k: ResumeAsync[int, int]):
+            return 99
+
+        caught_types: list[type] = []
+
+        def caller() -> int:
+            try:
+                return e()
+            except BaseException as ex:
+                caught_types.append(type(ex))
+                raise
+
+        result = await h(caller)
+        assert result == 99
+        assert gl.GreenletExit not in caught_types
+
+    @pytest.mark.asyncio
+    async def test_async_abort_finally_runs(self):
+        """Async abort should still run finally blocks."""
+        e: Effect[[], int] = effect("e")
+        h: AsyncHandler[int] = create_async_handler(e)
+
+        @h.on(e)
+        async def _handle(k: ResumeAsync[int, int]):
+            return 99
+
+        finally_ran = False
+
+        def caller() -> int:
+            nonlocal finally_ran
+            try:
+                return e()
+            finally:
+                finally_ran = True
+
+        result = await h(caller)
+        assert result == 99
+        assert finally_ran
+
+
+# ---------------------------------------------------------------------------
+# Stack cleanup after exceptions
+# ---------------------------------------------------------------------------
+
+
+class TestStackCleanupAfterException:
+    def test_stack_cleaned_after_handler_exception(self):
+        """Handler stack is cleaned even when handler fn raises."""
+        e: Effect[[], str] = effect("e")
+        h: Handler[str] = create_handler(e)
+
+        @h.on(e)
+        def _handle(k: Resume[str, str]):
+            raise ValueError("handler error")
+
+        with pytest.raises(ValueError):
+            h(lambda: e())
+
+        with pytest.raises(EffectNotHandledError):
+            e()
+
+    def test_stack_cleaned_after_computation_exception(self):
+        """Handler stack is cleaned when computation raises."""
+        e: Effect[[], str] = effect("e")
+        h: Handler[str] = create_handler(e)
+
+        @h.on(e)
+        def _handle(k: Resume[str, str]):
+            return k("val")
+
+        with pytest.raises(RuntimeError):
+            h(lambda: (_ for _ in ()).throw(RuntimeError("boom")))
+
+        with pytest.raises(EffectNotHandledError):
+            e()
+
+    def test_stack_cleaned_after_abort(self):
+        """Handler stack is cleaned after abort."""
+        e: Effect[[], int] = effect("e")
+        h: Handler[int] = create_handler(e)
+
+        @h.on(e)
+        def _handle(k: Resume[int, int]):
+            return 0
+
+        h(lambda: e())
+
+        with pytest.raises(EffectNotHandledError):
+            e()

--- a/tests/test_exception_oneshot.py
+++ b/tests/test_exception_oneshot.py
@@ -1,0 +1,441 @@
+"""Tests for exception integration with effect handlers (Issue #8).
+
+Defines and verifies the semantics for how exceptions interact with
+effect handlers in all supported scenarios.
+"""
+
+import asyncio  # pyright: ignore[reportUnusedImport]
+
+import pytest
+import pytest_asyncio  # pyright: ignore[reportUnusedImport]
+
+from aleff.oneshot import (
+    effect,
+    Effect,
+    Resume,
+    ResumeAsync,
+    Handler,
+    AsyncHandler,
+    create_handler,
+    create_async_handler,
+    EffectNotHandledError,
+)
+
+
+# ---------------------------------------------------------------------------
+# Exception in computation
+# ---------------------------------------------------------------------------
+
+
+class TestComputationException:
+    def test_exception_before_effect(self):
+        """Exception raised before any effect is performed."""
+        e: Effect[[], str] = effect("e")
+        h: Handler[str] = create_handler(e)
+
+        @h.on(e)
+        def _handle(k: Resume[str, str]):
+            return k("val")
+
+        with pytest.raises(RuntimeError, match="before effect"):
+            h(lambda: (_ for _ in ()).throw(RuntimeError("before effect")))
+
+    def test_exception_after_resume(self):
+        """Exception raised in computation after effect is resumed."""
+        e: Effect[[], int] = effect("e")
+        h: Handler[int] = create_handler(e)
+
+        @h.on(e)
+        def _handle(k: Resume[int, int]):
+            return k(42)
+
+        def caller() -> int:
+            val = e()
+            raise RuntimeError(f"after resume: {val}")
+
+        with pytest.raises(RuntimeError, match="after resume: 42"):
+            h(caller)
+
+    def test_handler_catches_computation_exception_via_resume(self):
+        """Handler can catch exceptions from computation via k()."""
+        e: Effect[[], int] = effect("e")
+        h: Handler[int] = create_handler(e)
+
+        @h.on(e)
+        def _handle(k: Resume[int, int]):
+            try:
+                return k(42)
+            except RuntimeError:
+                return -1
+
+        def caller() -> int:
+            e()
+            raise RuntimeError("computation error")
+
+        result = h(caller)
+        assert result == -1
+
+
+# ---------------------------------------------------------------------------
+# Exception in handler function
+# ---------------------------------------------------------------------------
+
+
+class TestHandlerException:
+    def test_handler_exception_before_resume(self):
+        """Exception in handler fn before calling k()."""
+        e: Effect[[], str] = effect("e")
+        h: Handler[str] = create_handler(e)
+
+        @h.on(e)
+        def _handle(k: Resume[str, str]):
+            raise ValueError("handler error")
+
+        with pytest.raises(ValueError, match="handler error"):
+            h(lambda: e())
+
+    def test_handler_exception_after_resume(self):
+        """Exception in handler fn after k() returns."""
+        e: Effect[[], int] = effect("e")
+        h: Handler[int] = create_handler(e)
+
+        @h.on(e)
+        def _handle(k: Resume[int, int]):
+            result = k(42)
+            raise ValueError(f"post-resume: {result}")
+
+        with pytest.raises(ValueError, match="post-resume: 42"):
+            h(lambda: e())
+
+    def test_handler_exception_wins_over_computation(self):
+        """When both handler and computation raise, handler's exception propagates."""
+        e: Effect[[], int] = effect("e")
+        h: Handler[int] = create_handler(e)
+
+        @h.on(e)
+        def _handle(k: Resume[int, int]):
+            try:
+                return k(42)
+            except RuntimeError:
+                pass
+            raise ValueError("handler error")
+
+        def caller() -> int:
+            e()
+            raise RuntimeError("computation error")
+
+        with pytest.raises(ValueError, match="handler error"):
+            h(caller)
+
+
+# ---------------------------------------------------------------------------
+# Abort (handler doesn't call resume) — GreenletExit must not leak
+# ---------------------------------------------------------------------------
+
+
+class TestAbortNoGreenletExitLeak:
+    def test_abort_basic(self):
+        """Handler returns without calling k() — computation is aborted."""
+        e: Effect[[], int] = effect("e")
+        h: Handler[int] = create_handler(e)
+
+        @h.on(e)
+        def _handle(k: Resume[int, int]):
+            return 99
+
+        result = h(lambda: e())
+        assert result == 99
+
+    def test_abort_does_not_leak_greenlet_exit(self):
+        """Abort must NOT expose GreenletExit to user code."""
+        import greenlet as gl
+
+        e: Effect[[], int] = effect("e")
+        h: Handler[int] = create_handler(e)
+
+        @h.on(e)
+        def _handle(k: Resume[int, int]):
+            return 99
+
+        caught_types: list[type] = []
+
+        def caller() -> int:
+            try:
+                return e()
+            except BaseException as ex:
+                caught_types.append(type(ex))
+                raise
+
+        result = h(caller)
+        assert result == 99
+        # GreenletExit must NOT appear in caught exceptions
+        assert gl.GreenletExit not in caught_types
+
+    def test_abort_finally_runs(self):
+        """Abort should still run finally blocks in the computation."""
+        e: Effect[[], int] = effect("e")
+        h: Handler[int] = create_handler(e)
+
+        @h.on(e)
+        def _handle(k: Resume[int, int]):
+            return 99
+
+        finally_ran = False
+
+        def caller() -> int:
+            nonlocal finally_ran
+            try:
+                return e()
+            finally:
+                finally_ran = True
+
+        result = h(caller)
+        assert result == 99
+        assert finally_ran
+
+    def test_abort_except_exception_does_not_catch(self):
+        """Abort should NOT be caught by 'except Exception'."""
+        e: Effect[[], int] = effect("e")
+        h: Handler[int] = create_handler(e)
+
+        @h.on(e)
+        def _handle(k: Resume[int, int]):
+            return 99
+
+        caught = False
+
+        def caller() -> int:
+            nonlocal caught
+            try:
+                return e()
+            except Exception:
+                caught = True
+                return -1
+
+        result = h(caller)
+        assert result == 99
+        assert not caught
+
+    def test_abort_caller_catches_and_performs_another_effect(self):
+        """If caller catches abort and performs another effect, abort persists."""
+        e1: Effect[[], int] = effect("e1")
+        e2: Effect[[], int] = effect("e2")
+        h: Handler[int] = create_handler(e1, e2)
+
+        @h.on(e1)
+        def _handle_e1(k: Resume[int, int]):
+            return 99  # abort
+
+        @h.on(e2)
+        def _handle_e2(k: Resume[int, int]):
+            return k(50)
+
+        attempts = 0
+
+        def caller() -> int:
+            nonlocal attempts
+            try:
+                return e1()
+            except BaseException:
+                attempts += 1
+                return e2()  # try another effect after catching abort
+
+        result = h(caller)
+        assert result == 99
+
+
+# ---------------------------------------------------------------------------
+# Nested handler exception propagation
+# ---------------------------------------------------------------------------
+
+
+class TestNestedException:
+    def test_exception_propagates_through_nested_handlers(self):
+        """Exception in innermost computation propagates through all handlers."""
+        e1: Effect[[], int] = effect("e1")
+        e2: Effect[[], int] = effect("e2")
+
+        h1: Handler[int] = create_handler(e1)
+        h2: Handler[int] = create_handler(e2)
+
+        @h1.on(e1)
+        def _h1(k: Resume[int, int]):
+            return k(10)
+
+        @h2.on(e2)
+        def _h2(k: Resume[int, int]):
+            return k(20)
+
+        def caller() -> int:
+            e1()
+            raise RuntimeError("nested error")
+
+        with pytest.raises(RuntimeError, match="nested error"):
+            h1(lambda: h2(caller))
+
+    def test_inner_handler_catches_exception(self):
+        """Inner handler can catch and recover from computation exception."""
+        e1: Effect[[], int] = effect("e1")
+        e2: Effect[[], int] = effect("e2")
+
+        h1: Handler[int] = create_handler(e1)
+        h2: Handler[int] = create_handler(e2)
+
+        @h1.on(e1)
+        def _h1(k: Resume[int, int]):
+            return k(10)
+
+        @h2.on(e2)
+        def _h2(k: Resume[int, int]):
+            try:
+                return k(20)
+            except RuntimeError:
+                return -1
+
+        def caller() -> int:
+            e1()
+            e2()
+            raise RuntimeError("error")
+
+        result = h1(lambda: h2(caller))
+        assert result == -1
+
+
+# ---------------------------------------------------------------------------
+# Async exception integration
+# ---------------------------------------------------------------------------
+
+
+class TestAsyncException:
+    @pytest.mark.asyncio
+    async def test_async_handler_exception_after_resume(self):
+        """Async handler fn raises after await k()."""
+        e: Effect[[], int] = effect("e")
+        h: AsyncHandler[int] = create_async_handler(e)
+
+        @h.on(e)
+        async def _handle(k: ResumeAsync[int, int]):
+            result = await k(42)
+            raise ValueError(f"async post-resume: {result}")
+
+        with pytest.raises(ValueError, match="async post-resume: 42"):
+            await h(lambda: e())
+
+    @pytest.mark.asyncio
+    async def test_async_handler_catches_computation_exception(self):
+        """Async handler catches exception from computation via k()."""
+        e: Effect[[], int] = effect("e")
+        h: AsyncHandler[int] = create_async_handler(e)
+
+        @h.on(e)
+        async def _handle(k: ResumeAsync[int, int]):
+            try:
+                return await k(42)
+            except RuntimeError:
+                return -1
+
+        def caller() -> int:
+            e()
+            raise RuntimeError("computation error")
+
+        result = await h(caller)
+        assert result == -1
+
+    @pytest.mark.asyncio
+    async def test_async_abort_does_not_leak_greenlet_exit(self):
+        """Async abort must NOT expose GreenletExit to user code."""
+        import greenlet as gl
+
+        e: Effect[[], int] = effect("e")
+        h: AsyncHandler[int] = create_async_handler(e)
+
+        @h.on(e)
+        async def _handle(k: ResumeAsync[int, int]):
+            return 99
+
+        caught_types: list[type] = []
+
+        def caller() -> int:
+            try:
+                return e()
+            except BaseException as ex:
+                caught_types.append(type(ex))
+                raise
+
+        result = await h(caller)
+        assert result == 99
+        assert gl.GreenletExit not in caught_types
+
+    @pytest.mark.asyncio
+    async def test_async_abort_finally_runs(self):
+        """Async abort should still run finally blocks."""
+        e: Effect[[], int] = effect("e")
+        h: AsyncHandler[int] = create_async_handler(e)
+
+        @h.on(e)
+        async def _handle(k: ResumeAsync[int, int]):
+            return 99
+
+        finally_ran = False
+
+        def caller() -> int:
+            nonlocal finally_ran
+            try:
+                return e()
+            finally:
+                finally_ran = True
+
+        result = await h(caller)
+        assert result == 99
+        assert finally_ran
+
+
+# ---------------------------------------------------------------------------
+# Stack cleanup after exceptions
+# ---------------------------------------------------------------------------
+
+
+class TestStackCleanupAfterException:
+    def test_stack_cleaned_after_handler_exception(self):
+        """Handler stack is cleaned even when handler fn raises."""
+        e: Effect[[], str] = effect("e")
+        h: Handler[str] = create_handler(e)
+
+        @h.on(e)
+        def _handle(k: Resume[str, str]):
+            raise ValueError("handler error")
+
+        with pytest.raises(ValueError):
+            h(lambda: e())
+
+        with pytest.raises(EffectNotHandledError):
+            e()
+
+    def test_stack_cleaned_after_computation_exception(self):
+        """Handler stack is cleaned when computation raises."""
+        e: Effect[[], str] = effect("e")
+        h: Handler[str] = create_handler(e)
+
+        @h.on(e)
+        def _handle(k: Resume[str, str]):
+            return k("val")
+
+        with pytest.raises(RuntimeError):
+            h(lambda: (_ for _ in ()).throw(RuntimeError("boom")))
+
+        with pytest.raises(EffectNotHandledError):
+            e()
+
+    def test_stack_cleaned_after_abort(self):
+        """Handler stack is cleaned after abort."""
+        e: Effect[[], int] = effect("e")
+        h: Handler[int] = create_handler(e)
+
+        @h.on(e)
+        def _handle(k: Resume[int, int]):
+            return 0
+
+        h(lambda: e())
+
+        with pytest.raises(EffectNotHandledError):
+            e()


### PR DESCRIPTION
## Summary

- Replace `caller_gl.throw(GreenletExit)` with a sentinel-based abort mechanism that does not expose internal exceptions to user code
- Add comprehensive exception integration tests

## Problem

When a handler aborts a computation (returns without calling `k()`), the library used `caller_gl.throw(GreenletExit)` to kill the caller greenlet. This exposed `GreenletExit` to user code — any `except BaseException` or `finally` block in the computation would see it. Since `GreenletExit` is a greenlet implementation detail, this was an abstraction leak.

## Solution

Introduced `EffectAborted(BaseException)` and an `ABORT` sentinel:

1. Instead of `caller_gl.throw(GreenletExit)`, the abort sends `ABORT` sentinel via `caller_gl.switch(ABORT)`
2. `_Effect.__call__` / `perform()` checks for `ABORT` and raises `EffectAborted`
3. `EffectAborted` inherits from `BaseException` (not `Exception`), so `except Exception` does not catch it
4. `finally` blocks still run normally
5. If the caller catches `EffectAborted` and performs another effect, the abort loop sends `ABORT` again until the greenlet dies

## Changes

- `src/aleff/_oneshot/v8_1/effects.py` — add `EffectAborted`, `ABORT`, check in `_Effect.__call__`
- `src/aleff/_oneshot/v8_1/handlers.py` — replace `throw(GreenletExit)` with `_abort_caller()`
- `src/aleff/_multishot/v1/effects.py` — add `EffectAborted`, `ABORT`, check in `perform()`
- `src/aleff/_multishot/v1/handlers.py` — replace `throw(GreenletExit)` with `_abort_caller()`
- `tests/test_exception.py` — 22 tests (multishot)
- `tests/test_exception_oneshot.py` — 20 tests (oneshot, multi-shot tests excluded)

## Commits

- `c5fbb5e` replace GreenletExit with EffectAborted for abort to prevent leaking internal exceptions to user code (#8)

## Test plan

- [x] 342 tests pass (`uv run pytest tests/`)
- [x] pyright 0 errors on all modified source and test files
- [x] Abort does not leak GreenletExit (sync and async)
- [x] `except Exception` does not catch abort
- [x] `finally` blocks run during abort
- [x] Caller catching abort and performing another effect is handled