### PR TITLE
upgrade build toolchains for C23 nullptr support

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -60,7 +60,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        os: [ubuntu-latest, macos-13, macos-14, windows-latest]
+        os: [ubuntu-latest, macos-15, windows-latest]
     steps:
       - uses: actions/checkout@v6
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -77,6 +77,7 @@ test-requires = ["pytest", "pytest-asyncio", "greenlet>=3.3.2"]
 
 [tool.cibuildwheel.linux]
 archs = ["x86_64"]
+manylinux-x86_64-image = "manylinux_2_28"
 
 [tool.cibuildwheel.macos]
 archs = ["x86_64", "arm64"]


### PR DESCRIPTION
Switch macOS CI runners from macos-13/macos-14 to macos-15 (Apple Clang 17) and set manylinux_2_28 image (GCC 14) for Linux wheel builds.