### PR TITLE
Release v0.3.0

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -67,7 +67,7 @@ jobs:
       - uses: astral-sh/setup-uv@v8.0.0
 
       - name: Build wheels
-        uses: pypa/cibuildwheel@v2.23
+        uses: pypa/cibuildwheel@v3.4.1
 
       - uses: actions/upload-artifact@v7
         with:

--- a/README.md
+++ b/README.md
@@ -10,6 +10,7 @@ Algebraic effects for Python — deep and shallow, stateful, composable, multi-s
 - **Multi-shot continuations** — `resume` can be called multiple times in a single handler, enabling backtracking search, non-determinism, and other advanced patterns
 - **Sync and async** — both synchronous (`Handler`) and asynchronous (`AsyncHandler`) handlers are supported, with transparent bridging between the two
 - **Effect composition** — handler functions can perform effects themselves, dispatched to enclosing handlers; enables layered architectures and modular effect stacking
+- **Dynamic wind** — `wind` context manager establishes before/after guards that are re-invoked on multi-shot re-entry, with optional auto-management of context managers returned by `before`
 - **Effect annotation** — `@effect(step1, step2)` collects effect sets transitively from decorated functions
 - **Introspection** — `effects(fn)` and `unhandled_effects(fn, h)` for querying and validating effect coverage
 - **Typed** — effect parameters and return types are checked by type checkers (pyright, ty)
@@ -123,6 +124,40 @@ result = h_log(lambda: h_parse(lambda: parse("42") + 1))
 print(result)  # 43
 ```
 
+### Dynamic wind
+
+The `wind` context manager establishes before/after guards around a dynamic extent. When a multi-shot continuation captured inside the `with` block is resumed, the `before` thunk is called again; when it exits, the `after` thunk runs.
+
+```python
+from aleff import effect, Effect, Resume, Handler, create_handler, wind
+
+choose: Effect[[], int] = effect("choose")
+h: Handler[list[int]] = create_handler(choose)
+
+@h.on(choose)
+def _choose(k: Resume[int, list[int]]):
+    return k(1) + k(2)
+
+log: list[str] = []
+
+def run() -> list[int]:
+    with wind(lambda: log.append("before"), lambda: log.append("after")):
+        return [choose() * 10]
+    assert False, "unreachable"
+
+result = h(run)
+print(result)  # [10, 20]
+print(log)     # ['before', 'after', 'before', 'after']
+```
+
+If `before` returns a context manager and `auto_exit=True` (the default), `__enter__` and `__exit__` are called automatically:
+
+```python
+with wind(lambda: open("data.txt")) as ref:
+    ref.unwrap().read()
+# file is closed on exit
+```
+
 ## How it works
 
 Effects are declared as typed values and invoked like regular function calls. A `Handler` intercepts these calls via greenlet-based context switching:
@@ -178,6 +213,8 @@ See [`examples/`](examples/) for demonstrations:
 | `AsyncHandler[V]` | Async handler protocol |
 | `Resume[R, V]` | Sync continuation (`k(value) -> V`) |
 | `ResumeAsync[R, V]` | Async continuation (`await k(value) -> V`) |
+| `wind(before, after, *, auto_exit=True)` | Dynamic wind context manager |
+| `Ref[T]` | Reference wrapper returned by `wind`; call `unwrap()` to get the value |
 
 ## Development
 

--- a/README.md
+++ b/README.md
@@ -158,6 +158,14 @@ with wind(lambda: open("data.txt")) as ref:
 # file is closed on exit
 ```
 
+`wind_range` is a multi-shot-safe replacement for `range()` in `for` loops. Python's `range()` iterator is shared across shots and exhausted after the first; `wind_range` saves and restores the iterator position automatically:
+
+```python
+with wind_range(n) as r:
+    for i in r:
+        v = choose()  # multi-shot safe
+```
+
 ## How it works
 
 Effects are declared as typed values and invoked like regular function calls. A `Handler` intercepts these calls via greenlet-based context switching:
@@ -214,6 +222,7 @@ See [`examples/`](examples/) for demonstrations:
 | `Resume[R, V]` | Sync continuation (`k(value) -> V`) |
 | `ResumeAsync[R, V]` | Async continuation (`await k(value) -> V`) |
 | `wind(before, after, *, auto_exit=True)` | Dynamic wind context manager |
+| `wind_range(stop)` / `wind_range(start, stop, step)` | Multi-shot-safe `range()` for `for` loops |
 | `Ref[T]` | Reference wrapper returned by `wind`; call `unwrap()` to get the value |
 
 ## Development

--- a/examples/demo_amb.py
+++ b/examples/demo_amb.py
@@ -18,7 +18,7 @@ Multi-shot pattern:
 
 from typing import Any, Callable
 
-from aleff import effect, Effect, Handler, Resume, create_handler
+from aleff import effect, Effect, Handler, Resume, create_handler, wind_range
 
 
 # ---------------------------------------------------------------------------
@@ -43,10 +43,9 @@ def run_amb(computation: Callable[[], list[Any]]) -> list[Any]:
     @h.on(amb)
     def _amb(k: Resume[int, list[Any]], values: list[int]) -> list[Any]:
         results: list[Any] = []
-        i = 0
-        while i < len(values):
-            results.extend(k(values[i]))
-            i += 1
+        with wind_range(len(values)) as r:
+            for i in r:
+                results.extend(k(values[i]))
         return results
 
     @h.on(require)

--- a/examples/demo_autodiff.py
+++ b/examples/demo_autodiff.py
@@ -10,8 +10,6 @@ primitive operations via effects. If the handler passes floats, it's normal
 evaluation. If it passes Dual numbers, derivatives propagate automatically.
 """
 
-from __future__ import annotations
-
 import math
 from dataclasses import dataclass
 from typing import Any, Callable

--- a/examples/demo_backprop.py
+++ b/examples/demo_backprop.py
@@ -16,8 +16,6 @@ Comparison:
   - backprop:   reverse-mode gradient accumulation with Num (shared grad)
 """
 
-from __future__ import annotations
-
 import math
 from dataclasses import dataclass
 from typing import Any, Callable

--- a/examples/demo_nqueens.py
+++ b/examples/demo_nqueens.py
@@ -12,7 +12,7 @@ Multi-shot pattern:
   independent local state.
 """
 
-from aleff import effect, Effect, Handler, Resume, create_handler
+from aleff import effect, Effect, Handler, Resume, create_handler, wind_range
 
 
 # ---------------------------------------------------------------------------
@@ -41,20 +41,19 @@ def solve(n: int) -> list[list[int]]:
     Returns a list of solutions.  Each solution is a list of column indices,
     one per row (e.g. [1, 3, 0, 2] means row0->col1, row1->col3, ...).
 
-    Uses a while loop instead of ``for row in range(n)`` because the
-    range iterator is a mutable object shared across multi-shot
-    continuations (Scheme semantics).  An int counter is immutable and
-    independent per shot.
+    Uses ``wind_range`` instead of ``range()`` because the range iterator
+    is a mutable object shared across multi-shot continuations.
+    ``wind_range`` saves and restores the iterator position via the wind
+    snapshot/restore mechanism.
     """
     queens: tuple[int, ...] = ()
-    row = 0
 
-    while row < n:
-        col = choose_col(n)
-        if not is_safe(queens, row, col):
-            return []  # dead end -- prune this branch
-        queens = (*queens, col)
-        row += 1
+    with wind_range(n) as rows:
+        for row in rows:
+            col = choose_col(n)
+            if not is_safe(queens, row, col):
+                return []  # dead end -- prune this branch
+            queens = (*queens, col)
 
     return [list(queens)]
 

--- a/examples/demo_probability.py
+++ b/examples/demo_probability.py
@@ -15,7 +15,7 @@ Multi-shot pattern:
 
 from typing import Callable
 
-from aleff import effect, Effect, Handler, Resume, create_handler
+from aleff import effect, Effect, Handler, Resume, create_handler, wind_range
 
 
 # ---------------------------------------------------------------------------
@@ -72,11 +72,10 @@ def two_coins() -> Dist:
 def three_coins_at_least_two() -> Dist:
     """Probability of getting at least 2 heads in 3 fair flips."""
     count = 0
-    i = 0
-    while i < 3:
-        if flip(0.5):
-            count += 1
-        i += 1
+    with wind_range(3) as r:
+        for _ in r:
+            if flip(0.5):
+                count += 1
     return {"yes": 1.0} if count >= 2 else {"no": 1.0}
 
 

--- a/examples/demo_record_replay.py
+++ b/examples/demo_record_replay.py
@@ -78,7 +78,7 @@ class EffectEntry:
         return {"effect": self.effect_name, "args": list(self.args), "result": self.result}
 
     @staticmethod
-    def from_dict(d: dict[str, Any]) -> EffectEntry:
+    def from_dict(d: dict[str, Any]) -> "EffectEntry":
         return EffectEntry(effect_name=d["effect"], args=tuple(d["args"]), result=d["result"])
 
 
@@ -107,7 +107,7 @@ class EffectLog:
         return json.dumps([e.to_dict() for e in self._entries], indent=2)
 
     @staticmethod
-    def from_json(s: str) -> EffectLog:
+    def from_json(s: str) -> "EffectLog":
         log = EffectLog()
         for d in json.loads(s):
             entry = EffectEntry.from_dict(d)

--- a/examples/demo_record_replay.py
+++ b/examples/demo_record_replay.py
@@ -9,8 +9,6 @@ Use cases:
   - Caching: reuse results of expensive external calls
 """
 
-from __future__ import annotations
-
 import json
 from dataclasses import dataclass
 from typing import Any

--- a/examples/demo_transaction.py
+++ b/examples/demo_transaction.py
@@ -7,8 +7,6 @@ Implement transaction semantics via effect handlers.
 - Abort (no resume) allows the handler to cancel the entire transaction
 """
 
-from __future__ import annotations
-
 from dataclasses import dataclass, field
 
 from aleff import (

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -77,7 +77,6 @@ test-requires = ["pytest", "pytest-asyncio", "greenlet>=3.3.2"]
 
 [tool.cibuildwheel.linux]
 archs = ["x86_64"]
-manylinux-x86_64-image = "manylinux_2_28"
 
 [tool.cibuildwheel.macos]
 archs = ["x86_64", "arm64"]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "aleff"
-version = "0.2.0"
+version = "0.3.0"
 description = "Algebraic effects for Python — deep and shallow, stateful, composable, multi-shot handlers"
 readme = "README.md"
 license = "Apache-2.0"

--- a/src/aleff/_multishot/v1/__init__.py
+++ b/src/aleff/_multishot/v1/__init__.py
@@ -33,7 +33,9 @@ from .utils import (
 from .misc import loglevel
 
 from .wind import (
+    WindBase,
     wind,
+    wind_range,
 )
 
 __all__ = [
@@ -49,6 +51,8 @@ __all__ = [
     "effects",
     "unhandled_effects",
     "loglevel",
+    "WindBase",
     "wind",
+    "wind_range",
     "Ref",
 ]

--- a/src/aleff/_multishot/v1/__init__.py
+++ b/src/aleff/_multishot/v1/__init__.py
@@ -13,6 +13,7 @@ from .intf import (
     ResumeAsync,
     Handler,
     AsyncHandler,
+    Ref,
 )
 
 from .effects import (
@@ -31,6 +32,10 @@ from .utils import (
 
 from .misc import loglevel
 
+from .wind import (
+    wind,
+)
+
 __all__ = [
     "Effect",
     "EffectNotHandledError",
@@ -44,4 +49,6 @@ __all__ = [
     "effects",
     "unhandled_effects",
     "loglevel",
+    "wind",
+    "Ref",
 ]

--- a/src/aleff/_multishot/v1/handlers.py
+++ b/src/aleff/_multishot/v1/handlers.py
@@ -18,6 +18,7 @@ from .intf import (
 from .effects import EffectContext, ABORT, EffectAborted
 from .misc import debug, eff_str
 from ._aleff import FrameSnapshot, restore_continuation, snapshot_from_frame
+from .wind import capture_wind_stack, rewind
 
 
 def create_handler(*effects: Effect[..., Any], shallow: bool = False) -> Handler[Any]:
@@ -71,6 +72,7 @@ class _Resume[R, V](Resume[R, V]):
         self._snapshot = snapshot
         self._token = token
         self._handler = handler
+        self._winds = capture_wind_stack(caller_gl)
 
     def __call__(self, value: R) -> V:
         caller_gl = self._caller_gl
@@ -101,8 +103,10 @@ class _Resume[R, V](Resume[R, V]):
         debug("||> @caller (multi-shot)")
 
         ss = self._snapshot
+        winds = self._winds
 
         def _body() -> V:
+            rewind(winds)
             return restore_continuation(ss, value)
 
         new_gl = gl.greenlet(_body)
@@ -126,6 +130,7 @@ class _ResumeAsync[R, V](ResumeAsync[R, V]):
         self._snapshot = snapshot
         self._token = token
         self._handler = handler
+        self._winds = capture_wind_stack(caller_gl)
 
     async def __call__(self, value: R) -> V:
         caller_gl = self._caller_gl
@@ -148,8 +153,10 @@ class _ResumeAsync[R, V](ResumeAsync[R, V]):
         debug("||> @caller (multi-shot async)")
 
         ss = self._snapshot
+        winds = self._winds
 
         def _body() -> V:
+            rewind(winds)
             return restore_continuation(ss, value)
 
         new_gl = gl.greenlet(_body)

--- a/src/aleff/_multishot/v1/intf.py
+++ b/src/aleff/_multishot/v1/intf.py
@@ -1,4 +1,5 @@
 from typing import Any, Callable, Concatenate, Coroutine, Protocol, runtime_checkable
+from types import TracebackType
 
 
 ##
@@ -151,6 +152,20 @@ class Ref[T](Protocol):
     """
 
     def unwrap(self) -> T: ...
+
+
+@runtime_checkable
+class Wind[T, B: bool | None](Protocol):
+    """Protocol for the ``wind`` context manager."""
+
+    def __enter__(self) -> Ref[T]: ...
+
+    def __exit__(
+        self,
+        exc_type: type[BaseException] | None,
+        exc_value: BaseException | None,
+        traceback: TracebackType | None,
+    ) -> B: ...
 
 
 class EffectNotHandledError[**P, R](RuntimeError):

--- a/src/aleff/_multishot/v1/intf.py
+++ b/src/aleff/_multishot/v1/intf.py
@@ -133,6 +133,26 @@ class AsyncHandler[V](Protocol):
         ...
 
 
+@runtime_checkable
+class Ref[T](Protocol):
+    """Indirect reference returned by :class:`wind` context manager.
+
+    ``wind`` wraps the return value of ``before()`` in a ``Ref`` so that
+    multi-shot continuation resumes can update the underlying value.
+    Use :meth:`unwrap` to retrieve the current value::
+
+        with wind(lambda: open("path.txt")) as ref:
+            ref.unwrap().read()
+
+    On multi-shot re-entry, ``before()`` is called again and the same
+    ``Ref`` object is updated with the new return value.  Because the
+    ``Ref`` is a heap object shared across shots, ``unwrap()`` always
+    returns the latest value even after frame restoration.
+    """
+
+    def unwrap(self) -> T: ...
+
+
 class EffectNotHandledError[**P, R](RuntimeError):
     """Raised when an effect is invoked but no handler is active for it."""
 

--- a/src/aleff/_multishot/v1/wind.py
+++ b/src/aleff/_multishot/v1/wind.py
@@ -293,28 +293,28 @@ class wind_range(WindBase["wind_range", int]):
     @property
     def start(self) -> int:
         return self._start
-    
+
     @property
     def stop(self) -> int:
         return self._stop
-    
+
     @property
     def step(self) -> int:
         return self._step
-    
+
     @overload
     def __init__(self, stop: int, /) -> None: ...
-    
+
     @overload
     def __init__(self, start: int, stop: int, step: int = 1, /) -> None: ...
-    
+
     def __init__(self, start: int, stop: int | None = None, step: int = 1) -> None:
         if stop is None:
             # wind_range(stop) form: start=0, stop=start
             start, stop = 0, start
         if step == 0:
             raise ValueError("step must not be zero")
-        
+
         self._start = start
         self._stop = stop
         self._step = step

--- a/src/aleff/_multishot/v1/wind.py
+++ b/src/aleff/_multishot/v1/wind.py
@@ -1,0 +1,186 @@
+from __future__ import annotations
+
+import inspect
+from contextvars import ContextVar
+from typing import Any, Callable
+import greenlet as gl
+from .intf import Ref
+
+
+class wind:
+    """Context manager that establishes a dynamic-wind guard.
+
+    Usage::
+
+        with wind(lambda: open("f.txt")) as ref:
+            ref.unwrap().read()
+
+        with wind(lambda: log("before"), lambda: log("after")):
+            ...
+
+        with wind(after=lambda: cleanup()):
+            ...
+    """
+
+    def __init__(
+        self,
+        before: Callable[[], Any] | None = None,
+        after: Callable[..., Any] | None = None,
+        *,
+        auto_exit: bool = True,
+    ) -> None:
+        self._entry = _WindEntry(before, after, auto_exit)
+
+    def __enter__(self) -> Ref[Any]:
+        ref = self._entry.enter()
+        stack = _get_wind_stack()
+        stack.append(self._entry)
+        _set_wind_stack(stack)
+        return ref
+
+    def __exit__(
+        self,
+        exc_type: type[BaseException] | None,
+        exc_val: BaseException | None,
+        exc_tb: Any,
+    ) -> bool:
+        stack = _get_wind_stack()
+        stack.pop()
+        _set_wind_stack(stack)
+        return self._entry.exit(exc_type, exc_val, exc_tb)
+
+
+def capture_wind_stack(caller_gl: gl.greenlet) -> list[_WindEntry]:
+    """Read the wind stack from a suspended greenlet's context."""
+    ctx = caller_gl.gr_context
+    if ctx is None:
+        return []
+    try:
+        return list(ctx[_wind_stack])
+    except KeyError:
+        return []
+
+
+def rewind(captured_winds: list[_WindEntry]) -> None:
+    """Transition from the current wind stack to *captured_winds*."""
+    _do_winds(_get_wind_stack(), captured_winds)
+
+
+class _Ref[T](Ref[T]):
+    __slots__ = ("value",)
+
+    def __init__(self, value: T) -> None:
+        self.value = value
+
+    def unwrap(self) -> T:
+        return self.value
+
+
+def _accepts_positional(fn: Callable[..., Any]) -> bool:
+    try:
+        sig = inspect.signature(fn)
+    except (ValueError, TypeError):
+        return False
+    for p in sig.parameters.values():
+        if p.kind in (
+            inspect.Parameter.POSITIONAL_ONLY,
+            inspect.Parameter.POSITIONAL_OR_KEYWORD,
+            inspect.Parameter.VAR_POSITIONAL,
+        ):
+            return True
+    return False
+
+
+class _WindEntry:
+    __slots__ = ("_before", "_after", "_auto_exit", "_cm", "_ref", "_raw_rv")
+
+    def __init__(
+        self,
+        before: Callable[[], Any] | None,
+        after: Callable[..., Any] | None,
+        auto_exit: bool,
+    ) -> None:
+        self._before = before
+        self._after = after
+        self._auto_exit = auto_exit
+        self._cm: Any = None
+        self._ref: _Ref[Any] | None = None
+        self._raw_rv: Any = None
+
+    def enter(self) -> _Ref[Any]:
+        if self._before is None:
+            self._cm = None
+            self._raw_rv = None
+            if self._ref is None:
+                self._ref = _Ref(None)
+            else:
+                self._ref.value = None
+            return self._ref
+
+        rv = self._before()
+        self._raw_rv = rv
+
+        if self._auto_exit and rv is not None and hasattr(rv, "__exit__"):
+            self._cm = rv
+            value = self._cm.__enter__()
+        else:
+            self._cm = None
+            value = rv
+
+        if self._ref is None:
+            self._ref = _Ref(value)
+        else:
+            self._ref.value = value
+        return self._ref
+
+    def exit(
+        self,
+        exc_type: type[BaseException] | None = None,
+        exc_val: BaseException | None = None,
+        exc_tb: Any = None,
+    ) -> bool:
+        suppress = False
+        if self._cm is not None:
+            suppress = bool(self._cm.__exit__(exc_type, exc_val, exc_tb))
+            self._cm = None
+        if self._after is not None:
+            if _accepts_positional(self._after):
+                self._after(self._raw_rv)
+            else:
+                self._after()
+        return suppress
+
+
+# -- Wind stack ContextVar --------------------------------------------------
+
+_wind_stack: ContextVar[list[_WindEntry]] = ContextVar("dynamic_wind_stack")
+
+
+def _get_wind_stack() -> list[_WindEntry]:
+    try:
+        return list(_wind_stack.get())
+    except LookupError:
+        return []
+
+
+def _set_wind_stack(stack: list[_WindEntry]) -> None:
+    _wind_stack.set(list(stack))
+
+
+def _do_winds(
+    from_winds: list[_WindEntry],
+    to_winds: list[_WindEntry],
+) -> None:
+    n = min(len(from_winds), len(to_winds))
+    common = 0
+    for i in range(n):
+        if from_winds[i] is to_winds[i]:
+            common = i + 1
+        else:
+            break
+
+    for entry in reversed(from_winds[common:]):
+        entry.exit()
+    for entry in to_winds[common:]:
+        entry.enter()
+    _set_wind_stack(list(to_winds))

--- a/src/aleff/_multishot/v1/wind.py
+++ b/src/aleff/_multishot/v1/wind.py
@@ -1,13 +1,197 @@
-from __future__ import annotations
-
+from abc import ABC, abstractmethod
+from contextlib import AbstractContextManager
+from dataclasses import dataclass
 import inspect
 from contextvars import ContextVar
-from typing import Any, Callable
+from typing import Any, Callable, cast, overload, TypeGuard
+from types import TracebackType
 import greenlet as gl
 from .intf import Ref
 
 
-class wind:
+@overload
+def wind[T](
+    before: Callable[[], AbstractContextManager[T]],
+    after: Callable[..., Any] | None = None,
+    *,
+    auto_exit: bool = True,
+) -> "WindBase[Ref[T], None]": ...
+
+
+@overload
+def wind[T](
+    before: Callable[[], T],
+    after: Callable[..., Any] | None = None,
+    *,
+    auto_exit: bool = True,
+) -> "WindBase[Ref[T], None]": ...
+
+
+@overload
+def wind(
+    before: None = None,
+    after: Callable[..., Any] | None = None,
+    *,
+    auto_exit: bool = True,
+) -> "WindBase[Ref[None], None]": ...
+
+
+def wind[T](
+    before: Callable[[], AbstractContextManager[T]] | Callable[[], T] | None = None,
+    after: Callable[..., Any] | None = None,
+    *,
+    auto_exit: bool = True,
+) -> "WindBase[Ref[T], None]":
+    if before is None:
+        # T is None
+        before = cast(Callable[[], T], lambda: None)
+    if after is None:
+        after = lambda: None
+    return _Wind[T](before, after, auto_exit=auto_exit)
+
+
+def wind_range(stop: int) -> "_WindRange":
+    return _WindRange(stop)
+
+
+class _Ref[T](Ref[T]):
+    __slots__ = ("value",)
+
+    def __init__(self, value: T) -> None:
+        self.value = value
+
+    def unwrap(self) -> T:
+        return self.value
+
+
+class WindBase[T, S](ABC):
+    """Base class for dynamic-wind context managers.
+
+    Subclasses implement the ``_wind_*`` protocol methods.  The base class
+    manages the wind stack and drives the snapshot/restore lifecycle for
+    multi-shot continuations.
+
+    T: type of the value yielded by ``__enter__`` (the ``as`` target)
+    S: type of the snapshot state for multi-shot re-entry
+
+    Protocol methods:
+
+    ``_wind_enter()``
+        Called on initial entry and on multi-shot re-entry.  Returns the
+        value that ``__enter__`` yields (the ``as`` target).
+
+    ``_wind_exit(exc_type, exc_val, exc_tb)``
+        Called on exit.  Returns ``True`` to suppress the exception.
+
+    ``_wind_snapshot()``
+        Called at continuation capture time.  Returns an opaque value that
+        will be passed to ``_wind_restore`` on re-entry.
+        Default: returns ``None``.
+
+    ``_wind_restore(state)``
+        Called before ``_wind_enter`` on multi-shot re-entry.  Receives
+        the value returned by ``_wind_snapshot`` at capture time.
+        Default: no-op.
+    """
+
+    def __enter__(self) -> T:
+        result = self._wind_enter()
+        _push_wind_entry(self)
+        return result
+
+    def __exit__(
+        self,
+        exc_type: type[BaseException] | None,
+        exc_val: BaseException | None,
+        exc_tb: Any,
+    ) -> bool:
+        _pop_wind_entry()
+        return self._wind_exit(exc_type, exc_val, exc_tb)
+
+    @abstractmethod
+    def _wind_enter(self) -> T: ...
+
+    def _wind_exit(
+        self,
+        exc_type: type[BaseException] | None = None,
+        exc_val: BaseException | None = None,
+        exc_tb: TracebackType | None = None,
+    ) -> bool:
+        return False
+
+    @abstractmethod
+    def _wind_snapshot(self) -> S: ...
+
+    def _wind_restore(self, state: S) -> None:
+        pass
+
+    @staticmethod
+    def _capture(caller_gl: gl.greenlet) -> "_CapturedWinds":
+        """Read the wind stack from a suspended greenlet's context and snapshot."""
+        ctx = caller_gl.gr_context
+        if ctx is None:
+            return []
+        try:
+            entries = list(ctx[_wind_stack])
+        except KeyError:
+            return []
+        return [_CapturedWindEntry(entry, entry._wind_snapshot()) for entry in entries]
+
+    @staticmethod
+    def _rewind(
+        from_winds: list["WindBase[Any, Any]"],
+        to_winds: "_CapturedWinds",
+    ) -> None:
+        """Transition the wind stack from *from_winds* to *to_winds*.
+
+        Called by :func:`rewind` during multi-shot continuation re-entry.
+        The two stacks may share a common prefix (same ``WindBase`` objects
+        at the same positions).  Entries in the common prefix are left
+        untouched — only the differing tails are unwound / rewound.
+
+        Steps:
+
+        1. Find the longest common prefix by identity (``is``) comparison.
+        Shared entries represent dynamic extents that are active in both
+        the current context and the captured context.
+        2. Unwind entries leaving: call ``_wind_exit()`` on entries in
+        *from_winds* beyond the common prefix, innermost first (reversed).
+        3. Rewind entries entering: for each entry in *to_winds* beyond the
+        common prefix, call ``_wind_restore(snapshot)`` to restore the
+        state captured at continuation capture time, then ``_wind_enter()``
+        to re-enter the dynamic extent.
+        4. Replace the wind stack with the entry list from *to_winds*.
+        """
+
+        to_entries = [item.entry for item in to_winds]
+
+        # 1. find the longest common prefix
+        n = min(len(from_winds), len(to_entries))
+        common = 0
+        for i in range(n):
+            if from_winds[i] is to_entries[i]:
+                common = i + 1
+            else:
+                break
+
+        exiting = from_winds[common:]
+        entering = to_winds[common:]
+
+        # 2. Unwind: exit extents we are leaving (innermost first).
+        for entry in reversed(exiting):
+            entry._wind_exit()
+
+        # 3. Rewind: restore snapshot then enter extents we are entering (outermost first).
+        for item in entering:
+            entry, snapshot = item.entry, item.snapshot
+            entry._wind_restore(snapshot)
+            entry._wind_enter()
+
+        # 4. Set the wind stack to the target state.
+        _set_wind_stack(list(to_entries))
+
+
+class _Wind[T](WindBase[Ref[T], None]):
     """Context manager that establishes a dynamic-wind guard.
 
     Usage::
@@ -24,59 +208,119 @@ class wind:
 
     def __init__(
         self,
-        before: Callable[[], Any] | None = None,
-        after: Callable[..., Any] | None = None,
+        before: Callable[[], AbstractContextManager[T]] | Callable[[], T],
+        after: Callable[[T], Any] | Callable[[], Any],
         *,
         auto_exit: bool = True,
     ) -> None:
-        self._entry = _WindEntry(before, after, auto_exit)
+        self._before = before
+        self._after = after
+        self._auto_exit = auto_exit
+        self._cm: AbstractContextManager[T] | None = None  # lifetime: _wind_enter() -> _wind_exit()
+        self._ref: _Ref[T] | None = None  # lifetime: ~_Wind
 
-    def __enter__(self) -> Ref[Any]:
-        ref = self._entry.enter()
-        stack = _get_wind_stack()
-        stack.append(self._entry)
-        _set_wind_stack(stack)
-        return ref
+    def _wind_enter(self) -> Ref[T]:
+        # In the normal lifecycle, _wind_exit (via __exit__ or _do_winds unwinding) always clears _item before _wind_enter is called again.
+        # A non-None _item here means the wind stack management has a bug — either __exit__ was skipped or _do_winds failed to unwind properly.
+        if self._cm is not None:
+            raise RuntimeError("wind entry already active")
 
-    def __exit__(
+        value = self._before()
+
+        if self._auto_exit and isinstance(value, AbstractContextManager):
+            self._cm = cast(AbstractContextManager[T], value)
+            value = self._cm.__enter__()
+            return self._update_ref(value)
+        else:
+            return self._update_ref(cast(T, value))
+
+    def _wind_exit(
         self,
-        exc_type: type[BaseException] | None,
-        exc_val: BaseException | None,
-        exc_tb: Any,
+        exc_type: type[BaseException] | None = None,
+        exc_val: BaseException | None = None,
+        exc_tb: TracebackType | None = None,
     ) -> bool:
-        stack = _get_wind_stack()
-        stack.pop()
-        _set_wind_stack(stack)
-        return self._entry.exit(exc_type, exc_val, exc_tb)
+        if self._ref is None:
+            raise RuntimeError("wind exit without active entry")
+
+        suppress = False
+        value = self._ref.unwrap()
+
+        if self._cm is not None:
+            suppress = bool(self._cm.__exit__(exc_type, exc_val, exc_tb))
+
+        if _accepts_positional(self._after):
+            self._after(value)
+        else:
+            fn = cast(Callable[[], Any], self._after)
+            fn()
+
+        # Clear _cm but NOT _ref.  _ref is a heap object shared with the
+        # restored frame in multi-shot continuations.  On re-entry,
+        # _wind_enter updates _ref.value in-place so the restored frame
+        # sees the new value via the same object reference.  Clearing
+        # _ref here would break that contract.
+        self._cm = None
+        return suppress
+
+    def _wind_snapshot(self) -> None:
+        return None
+
+    def _update_ref(self, value: T) -> Ref[T]:
+        if self._ref is None:
+            self._ref = _Ref(value)
+        else:
+            self._ref.value = value
+
+        return self._ref
 
 
-def capture_wind_stack(caller_gl: gl.greenlet) -> list[_WindEntry]:
-    """Read the wind stack from a suspended greenlet's context."""
-    ctx = caller_gl.gr_context
-    if ctx is None:
-        return []
-    try:
-        return list(ctx[_wind_stack])
-    except KeyError:
-        return []
+class _WindRange(WindBase["_WindRange", int]):
+    """Context manager providing multi-shot-safe range iteration.
+
+    Usage::
+
+        with wind_range(10) as r:
+            for i in r:
+                v = choose()   # multi-shot safe
+
+    On multi-shot re-entry, the iterator position is restored to the value
+    it had when the continuation was captured, so the ``for`` loop resumes
+    from the correct position.
+    """
+
+    def __init__(self, stop: int) -> None:
+        self._stop = stop
+        self._pos = 0
+
+    def _wind_enter(self) -> "_WindRange":
+        return self
+
+    def _wind_snapshot(self) -> int:
+        return self._pos
+
+    def _wind_restore(self, state: int) -> None:
+        self._pos = state
+
+    def __iter__(self) -> "_WindRange":
+        return self
+
+    def __next__(self) -> int:
+        if self._pos >= self._stop:
+            raise StopIteration
+        val = self._pos
+        self._pos += 1
+        return val
 
 
-def rewind(captured_winds: list[_WindEntry]) -> None:
-    """Transition from the current wind stack to *captured_winds*."""
-    _do_winds(_get_wind_stack(), captured_winds)
+def _accepts_positional(fn: Callable[..., Any]) -> TypeGuard[Callable[[Any], Any]]:
+    """Return True if *fn* accepts at least one positional argument.
 
-
-class _Ref[T](Ref[T]):
-    __slots__ = ("value",)
-
-    def __init__(self, value: T) -> None:
-        self.value = value
-
-    def unwrap(self) -> T:
-        return self.value
-
-
-def _accepts_positional(fn: Callable[..., Any]) -> bool:
+    Used to decide whether to call ``after(value)`` or ``after()``
+    when the wind guard exits.  Only positional-only, positional-or-keyword,
+    and ``*args`` parameters are considered; keyword-only and ``**kwargs``
+    are not, because the value is always passed positionally.
+    """
     try:
         sig = inspect.signature(fn)
     except (ValueError, TypeError):
@@ -91,96 +335,49 @@ def _accepts_positional(fn: Callable[..., Any]) -> bool:
     return False
 
 
-class _WindEntry:
-    __slots__ = ("_before", "_after", "_auto_exit", "_cm", "_ref", "_raw_rv")
-
-    def __init__(
-        self,
-        before: Callable[[], Any] | None,
-        after: Callable[..., Any] | None,
-        auto_exit: bool,
-    ) -> None:
-        self._before = before
-        self._after = after
-        self._auto_exit = auto_exit
-        self._cm: Any = None
-        self._ref: _Ref[Any] | None = None
-        self._raw_rv: Any = None
-
-    def enter(self) -> _Ref[Any]:
-        if self._before is None:
-            self._cm = None
-            self._raw_rv = None
-            if self._ref is None:
-                self._ref = _Ref(None)
-            else:
-                self._ref.value = None
-            return self._ref
-
-        rv = self._before()
-        self._raw_rv = rv
-
-        if self._auto_exit and rv is not None and hasattr(rv, "__exit__"):
-            self._cm = rv
-            value = self._cm.__enter__()
-        else:
-            self._cm = None
-            value = rv
-
-        if self._ref is None:
-            self._ref = _Ref(value)
-        else:
-            self._ref.value = value
-        return self._ref
-
-    def exit(
-        self,
-        exc_type: type[BaseException] | None = None,
-        exc_val: BaseException | None = None,
-        exc_tb: Any = None,
-    ) -> bool:
-        suppress = False
-        if self._cm is not None:
-            suppress = bool(self._cm.__exit__(exc_type, exc_val, exc_tb))
-            self._cm = None
-        if self._after is not None:
-            if _accepts_positional(self._after):
-                self._after(self._raw_rv)
-            else:
-                self._after()
-        return suppress
+# Type for captured wind entries: (entry, snapshot) pairs
+@dataclass(frozen=True, slots=True)
+class _CapturedWindEntry[T, S]:
+    entry: WindBase[T, S]
+    snapshot: S
 
 
-# -- Wind stack ContextVar --------------------------------------------------
+type _CapturedWinds = list[_CapturedWindEntry[Any, Any]]
 
-_wind_stack: ContextVar[list[_WindEntry]] = ContextVar("dynamic_wind_stack")
+_wind_stack: ContextVar[list[WindBase[Any, Any]]] = ContextVar("dynamic_wind_stack")
 
 
-def _get_wind_stack() -> list[_WindEntry]:
+# for handlers.py
+def capture_wind_stack(caller_gl: gl.greenlet) -> _CapturedWinds:
+    """Read the wind stack from a suspended greenlet's context and snapshot."""
+    return WindBase._capture(caller_gl)  # pyright: ignore[reportPrivateUsage]
+
+
+# for handlers.py
+def rewind(captured: _CapturedWinds) -> None:
+    """Transition from the current wind stack to *captured*."""
+    WindBase._rewind(_get_wind_stack(), captured)  # pyright: ignore[reportPrivateUsage]
+
+
+def _get_wind_stack() -> list[WindBase[Any, Any]]:
     try:
         return list(_wind_stack.get())
     except LookupError:
         return []
 
 
-def _set_wind_stack(stack: list[_WindEntry]) -> None:
+def _set_wind_stack(stack: list[WindBase[Any, Any]]) -> None:
     _wind_stack.set(list(stack))
 
 
-def _do_winds(
-    from_winds: list[_WindEntry],
-    to_winds: list[_WindEntry],
-) -> None:
-    n = min(len(from_winds), len(to_winds))
-    common = 0
-    for i in range(n):
-        if from_winds[i] is to_winds[i]:
-            common = i + 1
-        else:
-            break
+def _push_wind_entry(entry: WindBase[Any, Any]) -> None:
+    stack = _get_wind_stack()
+    stack.append(entry)
+    _set_wind_stack(stack)
 
-    for entry in reversed(from_winds[common:]):
-        entry.exit()
-    for entry in to_winds[common:]:
-        entry.enter()
-    _set_wind_stack(list(to_winds))
+
+def _pop_wind_entry() -> WindBase[Any, Any]:
+    stack = _get_wind_stack()
+    v = stack.pop()
+    _set_wind_stack(stack)
+    return v

--- a/src/aleff/_multishot/v1/wind.py
+++ b/src/aleff/_multishot/v1/wind.py
@@ -55,10 +55,6 @@ def wind[T, B: bool | None](  # pyright: ignore[reportInconsistentOverload]
     return _Wind[T](before, after, auto_exit=auto_exit)  # pyright: ignore[reportReturnType]
 
 
-def wind_range(stop: int) -> "_WindRange":
-    return _WindRange(stop)
-
-
 class _Ref[T](Ref[T]):
     __slots__ = ("value",)
 
@@ -280,7 +276,7 @@ class _Wind[T](WindBase[Ref[T], None]):
         return self._ref
 
 
-class _WindRange(WindBase["_WindRange", int]):
+class wind_range(WindBase["wind_range", int]):
     """Context manager providing multi-shot-safe range iteration.
 
     Usage::
@@ -294,11 +290,37 @@ class _WindRange(WindBase["_WindRange", int]):
     from the correct position.
     """
 
-    def __init__(self, stop: int) -> None:
+    @property
+    def start(self) -> int:
+        return self._start
+    
+    @property
+    def stop(self) -> int:
+        return self._stop
+    
+    @property
+    def step(self) -> int:
+        return self._step
+    
+    @overload
+    def __init__(self, stop: int, /) -> None: ...
+    
+    @overload
+    def __init__(self, start: int, stop: int, step: int = 1, /) -> None: ...
+    
+    def __init__(self, start: int, stop: int | None = None, step: int = 1) -> None:
+        if stop is None:
+            # wind_range(stop) form: start=0, stop=start
+            start, stop = 0, start
+        if step == 0:
+            raise ValueError("step must not be zero")
+        
+        self._start = start
         self._stop = stop
-        self._pos = 0
+        self._step = step
+        self._pos = start
 
-    def _wind_enter(self) -> "_WindRange":
+    def _wind_enter(self) -> "wind_range":
         return self
 
     def _wind_snapshot(self) -> int:
@@ -307,14 +329,16 @@ class _WindRange(WindBase["_WindRange", int]):
     def _wind_restore(self, state: int) -> None:
         self._pos = state
 
-    def __iter__(self) -> "_WindRange":
+    def __iter__(self) -> "wind_range":
         return self
 
     def __next__(self) -> int:
-        if self._pos >= self._stop:
+        sign = 1 if self._step > 0 else -1
+        ended = sign * self._pos >= sign * self._stop
+        if ended:
             raise StopIteration
         val = self._pos
-        self._pos += 1
+        self._pos += self._step
         return val
 
 

--- a/src/aleff/_multishot/v1/wind.py
+++ b/src/aleff/_multishot/v1/wind.py
@@ -3,51 +3,56 @@ from contextlib import AbstractContextManager
 from dataclasses import dataclass
 import inspect
 from contextvars import ContextVar
-from typing import Any, Callable, cast, overload, TypeGuard
+from typing import Any, Callable, cast, Literal, overload, TypeGuard
 from types import TracebackType
 import greenlet as gl
-from .intf import Ref
+from .intf import Ref, Wind
 
 
 @overload
-def wind[T](
-    before: Callable[[], AbstractContextManager[T]],
+def wind[T, B: bool | None](
+    before: Callable[[], AbstractContextManager[T, B]],
     after: Callable[..., Any] | None = None,
     *,
-    auto_exit: bool = True,
-) -> "WindBase[Ref[T], None]": ...
+    auto_exit: Literal[True] = True,
+) -> Wind[T, B]: ...
+
+
+@overload
+def wind[T, B: bool | None](
+    before: Callable[[], AbstractContextManager[T, B]],
+    after: Callable[..., Any] | None = None,
+    *,
+    auto_exit: Literal[False],
+) -> Wind[T, Literal[False]]: ...
 
 
 @overload
 def wind[T](
     before: Callable[[], T],
     after: Callable[..., Any] | None = None,
-    *,
-    auto_exit: bool = True,
-) -> "WindBase[Ref[T], None]": ...
+) -> Wind[T, Literal[False]]: ...
 
 
 @overload
 def wind(
     before: None = None,
     after: Callable[..., Any] | None = None,
-    *,
-    auto_exit: bool = True,
-) -> "WindBase[Ref[None], None]": ...
+) -> Wind[None, Literal[False]]: ...
 
 
-def wind[T](
-    before: Callable[[], AbstractContextManager[T]] | Callable[[], T] | None = None,
+def wind[T, B: bool | None](  # pyright: ignore[reportInconsistentOverload]
+    before: Callable[[], AbstractContextManager[T, B]] | Callable[[], T] | None = None,
     after: Callable[..., Any] | None = None,
     *,
     auto_exit: bool = True,
-) -> "WindBase[Ref[T], None]":
+) -> Wind[T, B]:
     if before is None:
         # T is None
         before = cast(Callable[[], T], lambda: None)
     if after is None:
         after = lambda: None
-    return _Wind[T](before, after, auto_exit=auto_exit)
+    return _Wind[T](before, after, auto_exit=auto_exit)  # pyright: ignore[reportReturnType]
 
 
 def wind_range(stop: int) -> "_WindRange":
@@ -102,11 +107,11 @@ class WindBase[T, S](ABC):
     def __exit__(
         self,
         exc_type: type[BaseException] | None,
-        exc_val: BaseException | None,
-        exc_tb: Any,
+        exc_value: BaseException | None,
+        traceback: Any,
     ) -> bool:
         _pop_wind_entry()
-        return self._wind_exit(exc_type, exc_val, exc_tb)
+        return self._wind_exit(exc_type, exc_value, traceback)
 
     @abstractmethod
     def _wind_enter(self) -> T: ...

--- a/tests/test_dynamic_wind.py
+++ b/tests/test_dynamic_wind.py
@@ -304,7 +304,6 @@ class TestWindOneShotEffect:
         def run() -> int:
             with wind(lambda: log.append("before"), lambda: log.append("after")):
                 return get_val() * 2
-            assert False, "unreachable"
 
         result = h(run)
         assert result == 20
@@ -329,7 +328,6 @@ class TestWindOneShotEffect:
                 a = read()
                 b = read()
                 return a + b
-            assert False, "unreachable"
 
         result = h(run)
         assert result == 3  # 1 + 2
@@ -350,7 +348,6 @@ class TestWindOneShotEffect:
             v = get_val()
             with wind(lambda: log.append("before"), lambda: log.append("after")):
                 return v * 10
-            assert False, "unreachable"
 
         result = h(run)
         assert result == 50
@@ -371,7 +368,6 @@ class TestWindOneShotEffect:
             with wind(lambda: log.append("outer-before"), lambda: log.append("outer-after")):
                 with wind(lambda: log.append("inner-before"), lambda: log.append("inner-after")):
                     return get_val()
-            assert False, "unreachable"
 
         result = h(run)
         assert result == 7
@@ -403,7 +399,6 @@ class TestWindMultiShot:
         def run() -> list[int]:
             with wind(lambda: log.append("before"), lambda: log.append("after")):
                 return [choose() * 10]
-            assert False, "unreachable"
 
         result = h(run)
         assert result == [10, 20]
@@ -423,7 +418,6 @@ class TestWindMultiShot:
         def run() -> list[int]:
             with wind(lambda: log.append("before"), lambda: log.append("after")):
                 return [choose()]
-            assert False, "unreachable"
 
         result = h(run)
         assert result == [1, 2, 3]
@@ -444,7 +438,6 @@ class TestWindMultiShot:
             with wind(lambda: log.append("outer-before"), lambda: log.append("outer-after")):
                 with wind(lambda: log.append("inner-before"), lambda: log.append("inner-after")):
                     return [choose()]
-            assert False, "unreachable"
 
         result = h(run)
         assert result == [1, 2]
@@ -476,7 +469,6 @@ class TestWindMultiShot:
             v = choose()
             with wind(lambda: log.append("before"), lambda: log.append("after")):
                 return [v * 10]
-            assert False, "unreachable"
 
         result = h(run)
         assert result == [10, 20]
@@ -498,7 +490,6 @@ class TestWindMultiShot:
                 v = choose()
                 log.append(f"body-{v}")
                 return [v]
-            assert False, "unreachable"
 
         result = h(run)
         assert result == [10, 20]
@@ -531,7 +522,6 @@ class TestWindMultiShot:
             with wind(before) as ref:
                 choose()
                 return [ref.unwrap()]
-            assert False, "unreachable"
 
         result = h(run)
         # Shot 1 (one-shot): before() returns 1, ref.unwrap() == 1, result [1]
@@ -560,7 +550,6 @@ class TestWindAbort:
         def run() -> int:
             with wind(lambda: log.append("before"), lambda: log.append("after")):
                 return e()
-            assert False, "unreachable"
 
         result = h(run, check=False)
         assert result == -1
@@ -581,7 +570,6 @@ class TestWindAbort:
             with wind(lambda: log.append("outer-before"), lambda: log.append("outer-after")):
                 with wind(lambda: log.append("inner-before"), lambda: log.append("inner-after")):
                     return e()
-            assert False, "unreachable"
 
         result = h(run, check=False)
         assert result == -1
@@ -619,12 +607,10 @@ class TestWindCrossExtent:
         def caller() -> list[int]:
             with wind(lambda: log.append("inner-before"), lambda: log.append("inner-after")):
                 return [choose()]
-            assert False, "unreachable"
 
         def run() -> list[int]:
             with wind(lambda: log.append("outer-before"), lambda: log.append("outer-after")):
                 return h(caller)
-            assert False, "unreachable"
 
         result = run()
         assert result == [1, 2]
@@ -668,7 +654,6 @@ class TestWindMultiShotException:
                 if v == 1:
                     raise ValueError("bad")
                 return v * 10
-            assert False, "unreachable"
 
         result = h(run)
         assert result == -1 + 20
@@ -750,7 +735,6 @@ class TestWindStackCleanup:
         def run() -> int:
             with wind(lambda: None, lambda: None):
                 return get_val()
-            assert False, "unreachable"
 
         h(run)
         assert _get_wind_stack() == []
@@ -767,7 +751,6 @@ class TestWindStackCleanup:
         def run() -> int:
             with wind(lambda: None, lambda: None):
                 return e()
-            assert False, "unreachable"
 
         h(run, check=False)
         assert _get_wind_stack() == []
@@ -784,7 +767,6 @@ class TestWindStackCleanup:
         def run() -> list[int]:
             with wind(lambda: None, lambda: None):
                 return [choose()]
-            assert False, "unreachable"
 
         h(run)
         assert _get_wind_stack() == []
@@ -808,7 +790,6 @@ class TestWindStackCleanup:
                 if v == 1:
                     raise ValueError("bad")
                 return v
-            assert False, "unreachable"
 
         h(run)
         assert _get_wind_stack() == []
@@ -831,7 +812,6 @@ class TestWindHandlerInteraction:
         def _handle(k: Resume[int, int]) -> int:
             with wind(lambda: log.append("handler-before"), lambda: log.append("handler-after")):
                 return k(42)
-            assert False, "unreachable"
 
         def run():
             return e()
@@ -852,12 +832,10 @@ class TestWindHandlerInteraction:
         def _handle(k: Resume[int, int]) -> int:
             with wind(lambda: log.append("handler-before"), lambda: log.append("handler-after")):
                 return k(10)
-            assert False, "unreachable"
 
         def run() -> int:
             with wind(lambda: log.append("caller-before"), lambda: log.append("caller-after")):
                 return e() * 2
-            assert False, "unreachable"
 
         result = h(run)
         assert result == 20
@@ -884,7 +862,6 @@ class TestWindHandlerInteraction:
         def run() -> int:
             with wind(lambda: None, lambda: None):
                 return e()
-            assert False, "unreachable"
 
         h(run)
         # The handler greenlet has no wind entries of its own
@@ -915,7 +892,6 @@ class TestWindHandlerInteraction:
                 with wind(lambda: log.append("wind-2-before"), lambda: log.append("wind-2-after")):
                     b = h_inner(lambda: inner_e())
                     return a + b
-            assert False, "unreachable"
 
         result = h_outer(run)
         assert result == 110
@@ -993,7 +969,6 @@ class TestRefCornerCases:
                 choose()
                 ref_ids.append(id(ref))
                 return [ref.unwrap()]
-            assert False, "unreachable"
 
         h(run)
         # Both shots should see the same Ref object (heap-shared)

--- a/tests/test_dynamic_wind.py
+++ b/tests/test_dynamic_wind.py
@@ -198,9 +198,9 @@ class TestWindAutoExit:
 
     def test_after_with_argument_receives_before_result(self):
         """after(value) receives before()'s return value when it accepts an argument."""
-        received: list[object] = []
+        received: list[int] = []
 
-        def after_fn(v: object) -> None:
+        def after_fn(v: int) -> None:
             received.append(v)
 
         with wind(lambda: 42, after_fn):

--- a/tests/test_dynamic_wind.py
+++ b/tests/test_dynamic_wind.py
@@ -1,0 +1,1001 @@
+"""Tests for wind context manager.
+
+wind(before, after, *, auto_exit=True) establishes a dynamic extent guard:
+- Entering the with block calls before() and pushes a wind entry
+- Exiting the with block pops the wind entry, calls cm.__exit__ if applicable, calls after()
+- On multi-shot resume, before() is called again before re-entering the extent
+- The return value of before() is wrapped in a Ref for multi-shot safety
+"""
+
+import pytest
+
+from aleff import (
+    effect,
+    Effect,
+    Resume,
+    Handler,
+    create_handler,
+    wind,
+    Ref,
+)
+from aleff._multishot.v1.wind import _get_wind_stack  # pyright: ignore[reportPrivateUsage]
+
+
+# ---------------------------------------------------------------------------
+# Basic behavior (no effects)
+# ---------------------------------------------------------------------------
+
+
+class TestWindBasic:
+    def test_before_and_after_order(self):
+        """before() runs on enter, after() runs on exit."""
+        log: list[str] = []
+        with wind(lambda: log.append("before"), lambda: log.append("after")):
+            log.append("body")
+        assert log == ["before", "body", "after"]
+
+    def test_after_only(self):
+        """after keyword argument works without before."""
+        log: list[str] = []
+        with wind(after=lambda: log.append("after")):
+            log.append("body")
+        assert log == ["body", "after"]
+
+    def test_before_only(self):
+        """before without after works."""
+        log: list[str] = []
+        with wind(lambda: log.append("before")):
+            log.append("body")
+        assert log == ["before", "body"]
+
+    def test_no_before_no_after(self):
+        """wind with no arguments acts as a no-op guard."""
+        with wind():
+            pass
+
+    def test_ref_wraps_before_return(self):
+        """as target receives a Ref wrapping before()'s return value."""
+        with wind(lambda: 42) as ref:
+            assert isinstance(ref, Ref)
+            assert ref.unwrap() == 42
+
+    def test_ref_wraps_none_when_no_before(self):
+        """as target is a Ref(None) when before is not provided."""
+        with wind(after=lambda: None) as ref:
+            assert isinstance(ref, Ref)
+            assert ref.unwrap() is None
+
+    def test_ref_wraps_none_when_before_returns_none(self):
+        """as target is a Ref(None) when before returns None."""
+        with wind(lambda: None) as ref:
+            assert isinstance(ref, Ref)
+            assert ref.unwrap() is None
+
+    def test_after_runs_on_exception(self):
+        """after() runs even if the body raises."""
+        log: list[str] = []
+        with pytest.raises(ValueError, match="boom"):
+            with wind(lambda: log.append("before"), lambda: log.append("after")):
+                raise ValueError("boom")
+        assert log == ["before", "after"]
+
+    def test_exception_propagates(self):
+        """Exception from the body propagates."""
+        with pytest.raises(ValueError, match="from body"):
+            with wind():
+                raise ValueError("from body")
+
+    def test_before_exception_skips_body_and_after(self):
+        """If before() raises, the body and after() are not executed."""
+        log: list[str] = []
+
+        def bad_before():
+            raise ValueError("before failed")
+
+        with pytest.raises(ValueError, match="before failed"):
+            with wind(bad_before, lambda: log.append("after")):
+                log.append("body")
+        assert log == []
+
+    def test_after_exception_propagates(self):
+        """If after() raises, its exception propagates."""
+
+        def bad_after():
+            raise ValueError("after failed")
+
+        with pytest.raises(ValueError, match="after failed"):
+            with wind(after=bad_after):
+                pass
+
+    def test_after_exception_masks_body_exception(self):
+        """If both body and after() raise, after()'s exception wins."""
+
+        def bad_after():
+            raise RuntimeError("after failed")
+
+        with pytest.raises(RuntimeError, match="after failed"):
+            with wind(after=bad_after):
+                raise ValueError("body failed")
+
+
+# ---------------------------------------------------------------------------
+# auto_exit: before() returning a context manager
+# ---------------------------------------------------------------------------
+
+
+class TestWindAutoExit:
+    def test_auto_exit_enters_and_exits_cm(self):
+        """When before() returns a cm and auto_exit=True, __enter__/__exit__ are called."""
+        log: list[str] = []
+
+        class CM:
+            def __enter__(self):
+                log.append("cm-enter")
+                return self
+
+            def __exit__(self, *exc_info: object) -> bool:
+                log.append("cm-exit")
+                return False
+
+        with wind(lambda: CM()) as ref:
+            log.append("body")
+            assert isinstance(ref.unwrap(), CM)
+        assert log == ["cm-enter", "body", "cm-exit"]
+
+    def test_auto_exit_false_skips_cm(self):
+        """When auto_exit=False, __enter__/__exit__ are not called."""
+        log: list[str] = []
+
+        class CM:
+            def __enter__(self):
+                log.append("cm-enter")
+                return self
+
+            def __exit__(self, *exc_info: object) -> bool:
+                log.append("cm-exit")
+                return False
+
+        with wind(lambda: CM(), auto_exit=False) as ref:
+            log.append("body")
+            assert isinstance(ref.unwrap(), CM)
+        assert log == ["body"]
+
+    def test_auto_exit_cm_receives_exception_info(self):
+        """cm.__exit__ receives exception info from the body."""
+        captured_exc: list[type | None] = []
+
+        class CM:
+            def __enter__(self):
+                return self
+
+            def __exit__(
+                self,
+                exc_type: type[BaseException] | None,
+                exc_val: BaseException | None,
+                exc_tb: object,
+            ) -> bool:
+                captured_exc.append(exc_type)
+                return False
+
+        with pytest.raises(ValueError):
+            with wind(lambda: CM()):
+                raise ValueError("oops")
+        assert captured_exc == [ValueError]
+
+    def test_auto_exit_cm_suppresses_exception(self):
+        """cm.__exit__ returning True suppresses the exception."""
+
+        class SuppressCM:
+            def __enter__(self):
+                return self
+
+            def __exit__(self, *exc_info: object) -> bool:
+                return True
+
+        # Should not raise
+        with wind(lambda: SuppressCM()):
+            raise ValueError("suppressed")
+
+    def test_after_with_argument_receives_before_result(self):
+        """after(value) receives before()'s return value when it accepts an argument."""
+        received: list[object] = []
+
+        def after_fn(v: object) -> None:
+            received.append(v)
+
+        with wind(lambda: 42, after_fn):
+            pass
+        assert received == [42]
+
+    def test_after_without_argument(self):
+        """after() with no parameter works fine."""
+        log: list[str] = []
+        with wind(lambda: 42, lambda: log.append("after")):
+            pass
+        assert log == ["after"]
+
+    def test_auto_exit_with_after(self):
+        """auto_exit cm and explicit after both run."""
+        log: list[str] = []
+
+        class CM:
+            def __enter__(self):
+                log.append("cm-enter")
+                return self
+
+            def __exit__(self, *exc_info: object) -> bool:
+                log.append("cm-exit")
+                return False
+
+        with wind(lambda: CM(), lambda: log.append("after")):
+            log.append("body")
+        assert log == ["cm-enter", "body", "cm-exit", "after"]
+
+
+# ---------------------------------------------------------------------------
+# Nested wind (no effects)
+# ---------------------------------------------------------------------------
+
+
+class TestWindNested:
+    def test_nested_enter_exit_order(self):
+        """Nested wind: outer-before, inner-before, inner-after, outer-after."""
+        log: list[str] = []
+        with wind(lambda: log.append("outer-before"), lambda: log.append("outer-after")):
+            with wind(lambda: log.append("inner-before"), lambda: log.append("inner-after")):
+                log.append("body")
+        assert log == [
+            "outer-before",
+            "inner-before",
+            "body",
+            "inner-after",
+            "outer-after",
+        ]
+
+    def test_nested_inner_exception_all_afters_run(self):
+        """When inner body raises, both after() thunks run in correct order."""
+        log: list[str] = []
+        with pytest.raises(ValueError, match="inner boom"):
+            with wind(lambda: log.append("outer-before"), lambda: log.append("outer-after")):
+                with wind(lambda: log.append("inner-before"), lambda: log.append("inner-after")):
+                    raise ValueError("inner boom")
+        assert log == [
+            "outer-before",
+            "inner-before",
+            "inner-after",
+            "outer-after",
+        ]
+
+    def test_triple_nested(self):
+        """Three levels of nesting work correctly."""
+        log: list[str] = []
+        with wind(lambda: log.append("A-before"), lambda: log.append("A-after")):
+            with wind(lambda: log.append("B-before"), lambda: log.append("B-after")):
+                with wind(lambda: log.append("C-before"), lambda: log.append("C-after")):
+                    log.append("body")
+        assert log == [
+            "A-before",
+            "B-before",
+            "C-before",
+            "body",
+            "C-after",
+            "B-after",
+            "A-after",
+        ]
+
+
+# ---------------------------------------------------------------------------
+# One-shot effects inside wind
+# ---------------------------------------------------------------------------
+
+
+class TestWindOneShotEffect:
+    def test_effect_inside_body(self):
+        """One-shot effect inside body: before and after called once each."""
+        get_val: Effect[[], int] = effect("get_val")
+        h: Handler[int] = create_handler(get_val)
+
+        @h.on(get_val)
+        def _get(k: Resume[int, int]):
+            return k(10)
+
+        log: list[str] = []
+
+        def run() -> int:
+            with wind(lambda: log.append("before"), lambda: log.append("after")):
+                return get_val() * 2
+            assert False, "unreachable"
+
+        result = h(run)
+        assert result == 20
+        assert log == ["before", "after"]
+
+    def test_multiple_effects_inside_body(self):
+        """Multiple one-shot effects inside body."""
+        read: Effect[[], int] = effect("read")
+        h: Handler[int] = create_handler(read)
+        call_count = 0
+
+        @h.on(read)
+        def _read(k: Resume[int, int]):
+            nonlocal call_count
+            call_count += 1
+            return k(call_count)
+
+        log: list[str] = []
+
+        def run() -> int:
+            with wind(lambda: log.append("before"), lambda: log.append("after")):
+                a = read()
+                b = read()
+                return a + b
+            assert False, "unreachable"
+
+        result = h(run)
+        assert result == 3  # 1 + 2
+        assert log == ["before", "after"]
+
+    def test_effect_outside_wind(self):
+        """Effect performed outside wind does not trigger before/after."""
+        get_val: Effect[[], int] = effect("get_val")
+        h: Handler[int] = create_handler(get_val)
+
+        @h.on(get_val)
+        def _get(k: Resume[int, int]):
+            return k(5)
+
+        log: list[str] = []
+
+        def run() -> int:
+            v = get_val()
+            with wind(lambda: log.append("before"), lambda: log.append("after")):
+                return v * 10
+            assert False, "unreachable"
+
+        result = h(run)
+        assert result == 50
+        assert log == ["before", "after"]
+
+    def test_nested_wind_with_effect(self):
+        """Effect inside nested wind with one-shot."""
+        get_val: Effect[[], int] = effect("get_val")
+        h: Handler[int] = create_handler(get_val)
+
+        @h.on(get_val)
+        def _get(k: Resume[int, int]):
+            return k(7)
+
+        log: list[str] = []
+
+        def run() -> int:
+            with wind(lambda: log.append("outer-before"), lambda: log.append("outer-after")):
+                with wind(lambda: log.append("inner-before"), lambda: log.append("inner-after")):
+                    return get_val()
+            assert False, "unreachable"
+
+        result = h(run)
+        assert result == 7
+        assert log == [
+            "outer-before",
+            "inner-before",
+            "inner-after",
+            "outer-after",
+        ]
+
+
+# ---------------------------------------------------------------------------
+# Multi-shot effects inside wind
+# ---------------------------------------------------------------------------
+
+
+class TestWindMultiShot:
+    def test_multishot_before_after_per_shot(self):
+        """Multi-shot: before() and after() called once per shot."""
+        choose: Effect[[], int] = effect("choose")
+        h: Handler[list[int]] = create_handler(choose)
+
+        @h.on(choose)
+        def _choose(k: Resume[int, list[int]]):
+            return k(1) + k(2)
+
+        log: list[str] = []
+
+        def run() -> list[int]:
+            with wind(lambda: log.append("before"), lambda: log.append("after")):
+                return [choose() * 10]
+            assert False, "unreachable"
+
+        result = h(run)
+        assert result == [10, 20]
+        assert log == ["before", "after", "before", "after"]
+
+    def test_multishot_three_shots(self):
+        """Multi-shot with three resumes."""
+        choose: Effect[[], int] = effect("choose")
+        h: Handler[list[int]] = create_handler(choose)
+
+        @h.on(choose)
+        def _choose(k: Resume[int, list[int]]):
+            return k(1) + k(2) + k(3)
+
+        log: list[str] = []
+
+        def run() -> list[int]:
+            with wind(lambda: log.append("before"), lambda: log.append("after")):
+                return [choose()]
+            assert False, "unreachable"
+
+        result = h(run)
+        assert result == [1, 2, 3]
+        assert log == ["before", "after", "before", "after", "before", "after"]
+
+    def test_multishot_nested_wind(self):
+        """Nested wind with multi-shot: all before/after called per shot."""
+        choose: Effect[[], int] = effect("choose")
+        h: Handler[list[int]] = create_handler(choose)
+
+        @h.on(choose)
+        def _choose(k: Resume[int, list[int]]):
+            return k(1) + k(2)
+
+        log: list[str] = []
+
+        def run() -> list[int]:
+            with wind(lambda: log.append("outer-before"), lambda: log.append("outer-after")):
+                with wind(lambda: log.append("inner-before"), lambda: log.append("inner-after")):
+                    return [choose()]
+            assert False, "unreachable"
+
+        result = h(run)
+        assert result == [1, 2]
+        assert log == [
+            # first shot (one-shot)
+            "outer-before",
+            "inner-before",
+            "inner-after",
+            "outer-after",
+            # second shot (multi-shot)
+            "outer-before",
+            "inner-before",
+            "inner-after",
+            "outer-after",
+        ]
+
+    def test_multishot_effect_outside_wind(self):
+        """Multi-shot effect outside wind: before/after called per shot naturally."""
+        choose: Effect[[], int] = effect("choose")
+        h: Handler[list[int]] = create_handler(choose)
+
+        @h.on(choose)
+        def _choose(k: Resume[int, list[int]]):
+            return k(1) + k(2)
+
+        log: list[str] = []
+
+        def run() -> list[int]:
+            v = choose()
+            with wind(lambda: log.append("before"), lambda: log.append("after")):
+                return [v * 10]
+            assert False, "unreachable"
+
+        result = h(run)
+        assert result == [10, 20]
+        assert log == ["before", "after", "before", "after"]
+
+    def test_multishot_winding_state_per_shot(self):
+        """Each multi-shot resume produces independent before/after pairs."""
+        choose: Effect[[], int] = effect("choose")
+        h: Handler[list[int]] = create_handler(choose)
+
+        @h.on(choose)
+        def _choose(k: Resume[int, list[int]]):
+            return k(10) + k(20)
+
+        log: list[str] = []
+
+        def run() -> list[int]:
+            with wind(lambda: log.append("before"), lambda: log.append("after")):
+                v = choose()
+                log.append(f"body-{v}")
+                return [v]
+            assert False, "unreachable"
+
+        result = h(run)
+        assert result == [10, 20]
+        assert log == [
+            "before",
+            "body-10",
+            "after",
+            "before",
+            "body-20",
+            "after",
+        ]
+
+    def test_multishot_ref_updated_on_reentry(self):
+        """Ref.unwrap() returns the new value from before() on multi-shot re-entry."""
+        choose: Effect[[], int] = effect("choose")
+        h: Handler[list[int]] = create_handler(choose)
+
+        @h.on(choose)
+        def _choose(k: Resume[int, list[int]]):
+            return k(1) + k(2)
+
+        call_count = 0
+
+        def before():
+            nonlocal call_count
+            call_count += 1
+            return call_count
+
+        def run() -> list[int]:
+            with wind(before) as ref:
+                choose()
+                return [ref.unwrap()]
+            assert False, "unreachable"
+
+        result = h(run)
+        # Shot 1 (one-shot): before() returns 1, ref.unwrap() == 1, result [1]
+        # Shot 2 (multi-shot): _do_winds calls before() → returns 2,
+        #   ref._value updated to 2, ref.unwrap() == 2, result [2]
+        assert result == [1, 2]
+
+
+# ---------------------------------------------------------------------------
+# Abort (handler doesn't call k)
+# ---------------------------------------------------------------------------
+
+
+class TestWindAbort:
+    def test_abort_calls_after(self):
+        """Handler abort (no resume) still calls after()."""
+        e: Effect[[], int] = effect("e")
+        h: Handler[int] = create_handler(e)
+
+        @h.on(e)
+        def _handle(k: Resume[int, int]):
+            return -1  # abort
+
+        log: list[str] = []
+
+        def run() -> int:
+            with wind(lambda: log.append("before"), lambda: log.append("after")):
+                return e()
+            assert False, "unreachable"
+
+        result = h(run, check=False)
+        assert result == -1
+        assert log == ["before", "after"]
+
+    def test_abort_nested_all_afters_run(self):
+        """Nested wind with abort: all after() thunks run."""
+        e: Effect[[], int] = effect("e")
+        h: Handler[int] = create_handler(e)
+
+        @h.on(e)
+        def _handle(k: Resume[int, int]):
+            return -1  # abort
+
+        log: list[str] = []
+
+        def run() -> int:
+            with wind(lambda: log.append("outer-before"), lambda: log.append("outer-after")):
+                with wind(lambda: log.append("inner-before"), lambda: log.append("inner-after")):
+                    return e()
+            assert False, "unreachable"
+
+        result = h(run, check=False)
+        assert result == -1
+        assert log == [
+            "outer-before",
+            "inner-before",
+            "inner-after",
+            "outer-after",
+        ]
+
+
+# ---------------------------------------------------------------------------
+# Cross-extent: multi-shot from different dynamic extents
+# ---------------------------------------------------------------------------
+
+
+class TestWindCrossExtent:
+    def test_shared_outer_extent(self):
+        """wind wrapping the handler invocation shares outer extent.
+
+        When the caller has [outer_entry, inner_entry] in its wind stack
+        and the handler is also inside the outer wind, the multi-shot
+        transition should only call before() for inner_entry (the shared
+        outer_entry is already active).
+        """
+        choose: Effect[[], int] = effect("choose")
+        h: Handler[list[int]] = create_handler(choose)
+
+        @h.on(choose)
+        def _choose(k: Resume[int, list[int]]):
+            return k(1) + k(2)
+
+        log: list[str] = []
+
+        def caller() -> list[int]:
+            with wind(lambda: log.append("inner-before"), lambda: log.append("inner-after")):
+                return [choose()]
+            assert False, "unreachable"
+
+        def run() -> list[int]:
+            with wind(lambda: log.append("outer-before"), lambda: log.append("outer-after")):
+                return h(caller)
+            assert False, "unreachable"
+
+        result = run()
+        assert result == [1, 2]
+        assert log == [
+            "outer-before",
+            # first shot (one-shot)
+            "inner-before",
+            "inner-after",
+            # second shot (multi-shot) - only inner rewound
+            "inner-before",
+            "inner-after",
+            "outer-after",
+        ]
+
+
+# ---------------------------------------------------------------------------
+# Multi-shot with exception inside body
+# ---------------------------------------------------------------------------
+
+
+class TestWindMultiShotException:
+    def test_multishot_exception_runs_after_per_shot(self):
+        """Multi-shot where one shot raises: after() still runs for each shot."""
+        choose: Effect[[], int] = effect("choose")
+        h: Handler[int] = create_handler(choose)
+
+        @h.on(choose)
+        def _choose(k: Resume[int, int]):
+            try:
+                r1 = k(1)
+            except ValueError:
+                r1 = -1
+            r2 = k(2)
+            return r1 + r2
+
+        log: list[str] = []
+
+        def run() -> int:
+            with wind(lambda: log.append("before"), lambda: log.append("after")):
+                v = choose()
+                if v == 1:
+                    raise ValueError("bad")
+                return v * 10
+            assert False, "unreachable"
+
+        result = h(run)
+        assert result == -1 + 20
+        assert log == ["before", "after", "before", "after"]
+
+
+# ---------------------------------------------------------------------------
+# Wind stack cleanup
+# ---------------------------------------------------------------------------
+
+
+class TestWindStackCleanup:
+    def test_stack_empty_after_normal_exit(self):
+        """Wind stack is empty after a normal with-block exit."""
+        with wind(lambda: None, lambda: None):
+            assert len(_get_wind_stack()) == 1
+        assert _get_wind_stack() == []
+
+    def test_stack_empty_after_exception(self):
+        """Wind stack is empty after the body raises."""
+        with pytest.raises(ValueError):
+            with wind(lambda: None, lambda: None):
+                raise ValueError("boom")
+        assert _get_wind_stack() == []
+
+    def test_stack_empty_after_before_exception(self):
+        """Wind stack is empty when before() raises (entry never pushed)."""
+
+        def bad_before():
+            raise ValueError("before failed")
+
+        with pytest.raises(ValueError):
+            with wind(bad_before):
+                pass
+        assert _get_wind_stack() == []
+
+    def test_stack_empty_after_after_exception(self):
+        """Wind stack is empty even when after() raises."""
+
+        def bad_after():
+            raise ValueError("after failed")
+
+        with pytest.raises(ValueError):
+            with wind(lambda: None, bad_after):
+                pass
+        assert _get_wind_stack() == []
+
+    def test_nested_stack_depth(self):
+        """Wind stack depth matches nesting level at each point."""
+        depths: list[int] = []
+        with wind(lambda: None, lambda: None):
+            depths.append(len(_get_wind_stack()))
+            with wind(lambda: None, lambda: None):
+                depths.append(len(_get_wind_stack()))
+                with wind(lambda: None, lambda: None):
+                    depths.append(len(_get_wind_stack()))
+                depths.append(len(_get_wind_stack()))
+            depths.append(len(_get_wind_stack()))
+        depths.append(len(_get_wind_stack()))
+        assert depths == [1, 2, 3, 2, 1, 0]
+
+    def test_stack_empty_after_nested_inner_exception(self):
+        """Wind stack is empty after an exception in nested wind body."""
+        with pytest.raises(ValueError):
+            with wind(lambda: None, lambda: None):
+                with wind(lambda: None, lambda: None):
+                    raise ValueError("nested boom")
+        assert _get_wind_stack() == []
+
+    def test_stack_empty_after_handler_with_wind(self):
+        """Wind stack is empty after a handler invocation that uses wind."""
+        get_val: Effect[[], int] = effect("get_val")
+        h: Handler[int] = create_handler(get_val)
+
+        @h.on(get_val)
+        def _get(k: Resume[int, int]):
+            return k(10)
+
+        def run() -> int:
+            with wind(lambda: None, lambda: None):
+                return get_val()
+            assert False, "unreachable"
+
+        h(run)
+        assert _get_wind_stack() == []
+
+    def test_stack_empty_after_abort(self):
+        """Wind stack is empty after handler abort."""
+        e: Effect[[], int] = effect("e")
+        h: Handler[int] = create_handler(e)
+
+        @h.on(e)
+        def _handle(k: Resume[int, int]):
+            return -1
+
+        def run() -> int:
+            with wind(lambda: None, lambda: None):
+                return e()
+            assert False, "unreachable"
+
+        h(run, check=False)
+        assert _get_wind_stack() == []
+
+    def test_stack_empty_after_multishot(self):
+        """Wind stack is empty after multi-shot handler completes."""
+        choose: Effect[[], int] = effect("choose")
+        h: Handler[list[int]] = create_handler(choose)
+
+        @h.on(choose)
+        def _choose(k: Resume[int, list[int]]):
+            return k(1) + k(2)
+
+        def run() -> list[int]:
+            with wind(lambda: None, lambda: None):
+                return [choose()]
+            assert False, "unreachable"
+
+        h(run)
+        assert _get_wind_stack() == []
+
+    def test_stack_empty_after_multishot_with_exception(self):
+        """Wind stack is empty after multi-shot where a shot raises."""
+        choose: Effect[[], int] = effect("choose")
+        h: Handler[int] = create_handler(choose)
+
+        @h.on(choose)
+        def _choose(k: Resume[int, int]):
+            try:
+                k(1)
+            except ValueError:
+                pass
+            return k(2)
+
+        def run() -> int:
+            with wind(lambda: None, lambda: None):
+                v = choose()
+                if v == 1:
+                    raise ValueError("bad")
+                return v
+            assert False, "unreachable"
+
+        h(run)
+        assert _get_wind_stack() == []
+
+
+# ---------------------------------------------------------------------------
+# Wind stack / handler stack interaction
+# ---------------------------------------------------------------------------
+
+
+class TestWindHandlerInteraction:
+    def test_wind_inside_handler_fn(self):
+        """wind used inside a handler function (handler greenlet context)."""
+        e: Effect[[], int] = effect("e")
+        h: Handler[int] = create_handler(e)
+
+        log: list[str] = []
+
+        @h.on(e)
+        def _handle(k: Resume[int, int]) -> int:
+            with wind(lambda: log.append("handler-before"), lambda: log.append("handler-after")):
+                return k(42)
+            assert False, "unreachable"
+
+        def run():
+            return e()
+
+        result = h(run)
+        assert result == 42
+        assert log == ["handler-before", "handler-after"]
+        assert _get_wind_stack() == []
+
+    def test_wind_in_caller_and_handler_independent(self):
+        """Wind in caller and wind in handler fn don't interfere."""
+        e: Effect[[], int] = effect("e")
+        h: Handler[int] = create_handler(e)
+
+        log: list[str] = []
+
+        @h.on(e)
+        def _handle(k: Resume[int, int]) -> int:
+            with wind(lambda: log.append("handler-before"), lambda: log.append("handler-after")):
+                return k(10)
+            assert False, "unreachable"
+
+        def run() -> int:
+            with wind(lambda: log.append("caller-before"), lambda: log.append("caller-after")):
+                return e() * 2
+            assert False, "unreachable"
+
+        result = h(run)
+        assert result == 20
+        assert "caller-before" in log
+        assert "caller-after" in log
+        assert "handler-before" in log
+        assert "handler-after" in log
+        assert _get_wind_stack() == []
+
+    def test_handler_cleanup_does_not_affect_wind_stack(self):
+        """Handler stack cleanup (_remove_all_handlers) leaves wind stack intact."""
+        e: Effect[[], int] = effect("e")
+        h: Handler[int] = create_handler(e)
+
+        wind_stack_during_handler: list[int] = []
+
+        @h.on(e)
+        def _handle(k: Resume[int, int]):
+            # Handler fn runs in handler greenlet.
+            # Check that handler's wind stack is separate from caller's.
+            wind_stack_during_handler.append(len(_get_wind_stack()))
+            return k(10)
+
+        def run() -> int:
+            with wind(lambda: None, lambda: None):
+                return e()
+            assert False, "unreachable"
+
+        h(run)
+        # The handler greenlet has no wind entries of its own
+        # (the caller's wind entries are in the caller's context)
+        assert wind_stack_during_handler == [0]
+        assert _get_wind_stack() == []
+
+    def test_interleaved_wind_and_handler_nesting(self):
+        """wind and handler nesting interleaved correctly."""
+        outer_e: Effect[[], int] = effect("outer_e")
+        inner_e: Effect[[], int] = effect("inner_e")
+        h_outer: Handler[int] = create_handler(outer_e)
+        h_inner: Handler[int] = create_handler(inner_e)
+
+        @h_outer.on(outer_e)
+        def _outer(k: Resume[int, int]):
+            return k(100)
+
+        @h_inner.on(inner_e)
+        def _inner(k: Resume[int, int]):
+            return k(10)
+
+        log: list[str] = []
+
+        def run() -> int:
+            with wind(lambda: log.append("wind-1-before"), lambda: log.append("wind-1-after")):
+                a = outer_e()
+                with wind(lambda: log.append("wind-2-before"), lambda: log.append("wind-2-after")):
+                    b = h_inner(lambda: inner_e())
+                    return a + b
+            assert False, "unreachable"
+
+        result = h_outer(run)
+        assert result == 110
+        assert log == [
+            "wind-1-before",
+            "wind-2-before",
+            "wind-2-after",
+            "wind-1-after",
+        ]
+        assert _get_wind_stack() == []
+
+
+# ---------------------------------------------------------------------------
+# __enter__ error paths
+# ---------------------------------------------------------------------------
+
+
+class TestWindEnterErrors:
+    def test_cm_enter_raises_does_not_push_to_stack(self):
+        """If cm.__enter__() raises, the wind entry is not left on the stack."""
+
+        class BadCM:
+            def __enter__(self):
+                raise RuntimeError("enter failed")
+
+            def __exit__(self, *exc_info: object) -> bool:
+                return False
+
+        with pytest.raises(RuntimeError, match="enter failed"):
+            with wind(lambda: BadCM()):
+                pass
+        assert _get_wind_stack() == []
+
+    def test_cm_exit_raises_stack_still_clean(self):
+        """If cm.__exit__() raises, the wind stack is still cleaned up."""
+
+        class BadExitCM:
+            def __enter__(self):
+                return self
+
+            def __exit__(self, *exc_info: object) -> bool:
+                raise RuntimeError("exit failed")
+
+        with pytest.raises(RuntimeError, match="exit failed"):
+            with wind(lambda: BadExitCM()):
+                pass
+        assert _get_wind_stack() == []
+
+
+# ---------------------------------------------------------------------------
+# Ref corner cases
+# ---------------------------------------------------------------------------
+
+
+class TestRefCornerCases:
+    def test_ref_unwrap_after_exit(self):
+        """Ref.unwrap() still returns the last value after with-block exit."""
+        with wind(lambda: 99) as ref:
+            pass
+        assert ref.unwrap() == 99
+
+    def test_ref_identity_preserved_across_multishot(self):
+        """The same Ref object is reused across multi-shot re-entries."""
+        choose: Effect[[], int] = effect("choose")
+        h: Handler[list[int]] = create_handler(choose)
+
+        @h.on(choose)
+        def _choose(k: Resume[int, list[int]]):
+            return k(1) + k(2)
+
+        ref_ids: list[int] = []
+
+        def run() -> list[int]:
+            with wind(lambda: 0) as ref:
+                choose()
+                ref_ids.append(id(ref))
+                return [ref.unwrap()]
+            assert False, "unreachable"
+
+        h(run)
+        # Both shots should see the same Ref object (heap-shared)
+        assert len(ref_ids) == 2
+        assert ref_ids[0] == ref_ids[1]

--- a/tests/test_wind_range.py
+++ b/tests/test_wind_range.py
@@ -326,8 +326,14 @@ class TestWindRangeMultiShot:
         result = h(run)
         # range(0,6,2) = [0,2,4], 3 iterations, 2^3 = 8 leaves
         assert result == [
-            (0, 0, 0), (0, 0, 1), (0, 1, 0), (0, 1, 1),
-            (1, 0, 0), (1, 0, 1), (1, 1, 0), (1, 1, 1),
+            (0, 0, 0),
+            (0, 0, 1),
+            (0, 1, 0),
+            (0, 1, 1),
+            (1, 0, 0),
+            (1, 0, 1),
+            (1, 1, 0),
+            (1, 1, 1),
         ]
 
     def test_loop_index_available(self):

--- a/tests/test_wind_range.py
+++ b/tests/test_wind_range.py
@@ -1,0 +1,350 @@
+"""Tests for wind_range context manager.
+
+wind_range provides multi-shot-safe range iteration by saving and
+restoring the iterator position via the wind snapshot/restore mechanism.
+
+Multi-shot tests use ``v = choose(); choices = choices + (v,)`` instead of
+``choices = (*choices, choose())``.  The latter creates an intermediate
+mutable list on the heap that is shared across shots.
+"""
+
+import pytest
+
+from aleff import (
+    effect,
+    Effect,
+    Resume,
+    Handler,
+    create_handler,
+    wind,
+    wind_range,
+)
+from aleff._multishot.v1.wind import _get_wind_stack  # pyright: ignore[reportPrivateUsage]
+
+
+# ---------------------------------------------------------------------------
+# Basic (no effects)
+# ---------------------------------------------------------------------------
+
+
+class TestWindRangeBasic:
+    def test_iterates_correctly(self):
+        """wind_range produces the same values as range()."""
+        result: list[int] = []
+        with wind_range(5) as r:
+            for i in r:
+                result.append(i)
+        assert result == [0, 1, 2, 3, 4]
+
+    def test_empty_range(self):
+        """wind_range(0) produces no values."""
+        result: list[int] = []
+        with wind_range(0) as r:
+            for i in r:
+                result.append(i)
+        assert result == []
+
+    def test_range_one(self):
+        """wind_range(1) produces [0]."""
+        result: list[int] = []
+        with wind_range(1) as r:
+            for i in r:
+                result.append(i)
+        assert result == [0]
+
+    def test_nested_wind_range(self):
+        """Nested wind_range loops."""
+        result: list[tuple[int, int]] = []
+        with wind_range(3) as outer:
+            for i in outer:
+                with wind_range(2) as inner:
+                    for j in inner:
+                        result.append((i, j))
+        assert result == [(0, 0), (0, 1), (1, 0), (1, 1), (2, 0), (2, 1)]
+
+    def test_no_effects_behaves_like_range(self):
+        """Without effects, wind_range behaves identically to range."""
+        total = 0
+        with wind_range(10) as r:
+            for i in r:
+                total += i
+        assert total == sum(range(10))
+
+
+# ---------------------------------------------------------------------------
+# Multi-shot
+# ---------------------------------------------------------------------------
+
+
+class TestWindRangeMultiShot:
+    def test_cartesian_product_2(self):
+        """choose() per iteration with wind_range(2) produces 2^2 = 4 results."""
+        choose: Effect[[], int] = effect("choose")
+        h: Handler[list[tuple[int, ...]]] = create_handler(choose)
+
+        @h.on(choose)
+        def _choose(k: Resume[int, list[tuple[int, ...]]]):
+            return k(0) + k(1)
+
+        def run() -> list[tuple[int, ...]]:
+            choices: tuple[int, ...] = ()
+            with wind_range(2) as r:
+                for _ in r:
+                    v = choose()
+                    choices = choices + (v,)
+            return [choices]
+
+        result = h(run)
+        # Cartesian product {0,1}^2, depth-first order
+        assert result == [(0, 0), (0, 1), (1, 0), (1, 1)]
+
+    def test_cartesian_product_3(self):
+        """choose() per iteration with wind_range(3) produces 2^3 = 8 results."""
+        choose: Effect[[], int] = effect("choose")
+        h: Handler[list[tuple[int, ...]]] = create_handler(choose)
+
+        @h.on(choose)
+        def _choose(k: Resume[int, list[tuple[int, ...]]]):
+            return k(0) + k(1)
+
+        def run() -> list[tuple[int, ...]]:
+            choices: tuple[int, ...] = ()
+            with wind_range(3) as r:
+                for _ in r:
+                    v = choose()
+                    choices = choices + (v,)
+            return [choices]
+
+        result = h(run)
+        assert result == [
+            (0, 0, 0),
+            (0, 0, 1),
+            (0, 1, 0),
+            (0, 1, 1),
+            (1, 0, 0),
+            (1, 0, 1),
+            (1, 1, 0),
+            (1, 1, 1),
+        ]
+
+    def test_single_effect_mid_loop(self):
+        """Single choose() at a specific iteration — loop continues correctly."""
+        choose: Effect[[], int] = effect("choose")
+        h: Handler[list[int]] = create_handler(choose)
+
+        @h.on(choose)
+        def _choose(k: Resume[int, list[int]]):
+            return k(100) + k(200)
+
+        def run() -> list[int]:
+            total = 0
+            with wind_range(4) as r:
+                for i in r:
+                    if i == 2:
+                        total += choose()
+                    else:
+                        total += i
+            return [total]
+
+        result = h(run)
+        # At i=2: snapshot, total=0+1=1 (immutable int, frame-local)
+        # Shot 1: 1 + 100 + 3 = 104
+        # Shot 2: restore pos=3, total=1, 1 + 200 + 3 = 204
+        assert result == [104, 204]
+
+    def test_effect_before_loop(self):
+        """Effect before the loop — wind_range restores pos for each shot."""
+        choose: Effect[[], int] = effect("choose")
+        h: Handler[list[int]] = create_handler(choose)
+
+        @h.on(choose)
+        def _choose(k: Resume[int, list[int]]):
+            return k(10) + k(20)
+
+        def run() -> list[int]:
+            total = 0
+            with wind_range(3) as r:
+                base = choose()
+                total = base
+                for i in r:
+                    total += i
+            return [total]
+
+        result = h(run)
+        # Shot 1: base=10, loop i=0,1,2 → 10+0+1+2 = 13
+        # Shot 2: restore pos=0, base=20 → 20+0+1+2 = 23
+        assert result == [13, 23]
+
+    def test_three_way_multishot(self):
+        """3-way multi-shot with wind_range(2) produces 3^2 = 9 results."""
+        choose: Effect[[], int] = effect("choose")
+        h: Handler[list[tuple[int, ...]]] = create_handler(choose)
+
+        @h.on(choose)
+        def _choose(k: Resume[int, list[tuple[int, ...]]]):
+            return k(0) + k(1) + k(2)
+
+        def run() -> list[tuple[int, ...]]:
+            choices: tuple[int, ...] = ()
+            with wind_range(2) as r:
+                for _ in r:
+                    v = choose()
+                    choices = choices + (v,)
+            return [choices]
+
+        result = h(run)
+        assert result == [
+            (0, 0),
+            (0, 1),
+            (0, 2),
+            (1, 0),
+            (1, 1),
+            (1, 2),
+            (2, 0),
+            (2, 1),
+            (2, 2),
+        ]
+
+    def test_loop_index_available(self):
+        """Loop index from wind_range is correctly captured per shot."""
+        choose: Effect[[], int] = effect("choose")
+        h: Handler[list[tuple[int, int]]] = create_handler(choose)
+
+        @h.on(choose)
+        def _choose(k: Resume[int, list[tuple[int, int]]]):
+            return k(100) + k(200)
+
+        def run() -> list[tuple[int, int]]:
+            with wind_range(3) as r:
+                for i in r:
+                    v = choose()
+                    return [(i, v)]
+            assert False, "unreachable"
+
+        result = h(run)
+        # return on first iteration, so i=0 always
+        assert result == [(0, 100), (0, 200)]
+
+    def test_immutable_total_per_shot(self):
+        """Immutable accumulator (int) is independent per shot."""
+        choose: Effect[[], int] = effect("choose")
+        h: Handler[list[int]] = create_handler(choose)
+
+        @h.on(choose)
+        def _choose(k: Resume[int, list[int]]):
+            return k(10) + k(20)
+
+        def run() -> list[int]:
+            total = 0
+            with wind_range(3) as r:
+                for _ in r:
+                    v = choose()
+                    total = total + v
+            return [total]
+
+        result = h(run)
+        # 3 iterations, each choose() forks 2 ways → 2^3 = 8 leaves
+        # Each leaf is a sum of 3 choices from {10, 20}
+        assert sorted(result) == sorted(
+            [
+                10 + 10 + 10,  # 30
+                10 + 10 + 20,  # 40
+                10 + 20 + 10,  # 40
+                10 + 20 + 20,  # 50
+                20 + 10 + 10,  # 40
+                20 + 10 + 20,  # 50
+                20 + 20 + 10,  # 50
+                20 + 20 + 20,  # 60
+            ]
+        )
+
+
+# ---------------------------------------------------------------------------
+# Stack cleanup
+# ---------------------------------------------------------------------------
+
+
+class TestWindRangeStackCleanup:
+    def test_stack_empty_after_normal_exit(self):
+        """Wind stack is empty after wind_range exits normally."""
+        with wind_range(5) as r:
+            for _ in r:
+                pass
+        assert _get_wind_stack() == []
+
+    def test_stack_empty_after_multishot(self):
+        """Wind stack is empty after multi-shot with wind_range completes."""
+        choose: Effect[[], int] = effect("choose")
+        h: Handler[list[int]] = create_handler(choose)
+
+        @h.on(choose)
+        def _choose(k: Resume[int, list[int]]):
+            return k(1) + k(2)
+
+        def run() -> list[int]:
+            with wind_range(3) as r:
+                for i in r:
+                    return [choose() + i]
+            assert False, "unreachable"
+
+        h(run)
+        assert _get_wind_stack() == []
+
+
+# ---------------------------------------------------------------------------
+# Corner cases
+# ---------------------------------------------------------------------------
+
+
+class TestWindRangeCornerCases:
+    def test_abort(self):
+        """Handler abort with wind_range still cleans up."""
+        e: Effect[[], int] = effect("e")
+        h: Handler[int] = create_handler(e)
+
+        @h.on(e)
+        def _handle(k: Resume[int, int]):
+            return -1  # abort
+
+        def run() -> int:
+            with wind_range(5) as r:
+                for i in r:
+                    if i == 2:
+                        return e()
+            return 0
+
+        result = h(run, check=False)
+        assert result == -1
+        assert _get_wind_stack() == []
+
+    def test_exception_in_body(self):
+        """Exception in loop body propagates and cleans up."""
+        with pytest.raises(ValueError, match="boom"):
+            with wind_range(5) as r:
+                for i in r:
+                    if i == 3:
+                        raise ValueError("boom")
+        assert _get_wind_stack() == []
+
+    def test_wind_and_wind_range_combined(self):
+        """wind and wind_range can be nested together."""
+        choose: Effect[[], int] = effect("choose")
+        h: Handler[list[int]] = create_handler(choose)
+
+        @h.on(choose)
+        def _choose(k: Resume[int, list[int]]):
+            return k(10) + k(20)
+
+        log: list[str] = []
+
+        def run() -> list[int]:
+            with wind(lambda: log.append("before"), lambda: log.append("after")):
+                with wind_range(2) as r:
+                    for i in r:
+                        return [choose() + i]
+            assert False, "unreachable"
+
+        h(run)
+        assert log.count("before") == 2
+        assert log.count("after") == 2
+        assert _get_wind_stack() == []

--- a/tests/test_wind_range.py
+++ b/tests/test_wind_range.py
@@ -70,6 +70,82 @@ class TestWindRangeBasic:
                 total += i
         assert total == sum(range(10))
 
+    # -- start, stop, step interface --
+
+    def test_start_stop(self):
+        """wind_range(start, stop) produces values from start to stop-1."""
+        result: list[int] = []
+        with wind_range(2, 6) as r:
+            for i in r:
+                result.append(i)
+        assert result == list(range(2, 6))
+
+    def test_start_stop_step(self):
+        """wind_range(start, stop, step) produces values with stride."""
+        result: list[int] = []
+        with wind_range(1, 10, 3) as r:
+            for i in r:
+                result.append(i)
+        assert result == list(range(1, 10, 3))
+
+    def test_negative_step(self):
+        """wind_range with negative step counts downward."""
+        result: list[int] = []
+        with wind_range(10, 0, -2) as r:
+            for i in r:
+                result.append(i)
+        assert result == list(range(10, 0, -2))
+
+    def test_step_positive_empty(self):
+        """wind_range(5, 2) with positive step produces no values."""
+        result: list[int] = []
+        with wind_range(5, 2) as r:
+            for i in r:
+                result.append(i)
+        assert result == []
+
+    def test_step_negative_empty(self):
+        """wind_range(2, 5, -1) produces no values."""
+        result: list[int] = []
+        with wind_range(2, 5, -1) as r:
+            for i in r:
+                result.append(i)
+        assert result == []
+
+    def test_step_zero_raises(self):
+        """wind_range with step=0 raises ValueError like range()."""
+        with pytest.raises(ValueError):
+            wind_range(0, 10, 0)
+
+    def test_single_arg_matches_range(self):
+        """wind_range(n) matches range(n) for various n."""
+        for n in [0, 1, 5, 10]:
+            result: list[int] = []
+            with wind_range(n) as r:
+                for i in r:
+                    result.append(i)
+            assert result == list(range(n))
+
+    def test_two_arg_matches_range(self):
+        """wind_range(a, b) matches range(a, b) for various a, b."""
+        cases = [(0, 5), (3, 3), (5, 2), (-3, 3), (0, 0)]
+        for a, b in cases:
+            result: list[int] = []
+            with wind_range(a, b) as r:
+                for i in r:
+                    result.append(i)
+            assert result == list(range(a, b)), f"wind_range({a}, {b})"
+
+    def test_three_arg_matches_range(self):
+        """wind_range(a, b, c) matches range(a, b, c) for various a, b, c."""
+        cases = [(0, 10, 2), (10, 0, -1), (0, 10, 3), (-5, 5, 2), (5, -5, -3)]
+        for a, b, c in cases:
+            result: list[int] = []
+            with wind_range(a, b, c) as r:
+                for i in r:
+                    result.append(i)
+            assert result == list(range(a, b, c)), f"wind_range({a}, {b}, {c})"
+
 
 # ---------------------------------------------------------------------------
 # Multi-shot
@@ -203,6 +279,55 @@ class TestWindRangeMultiShot:
             (2, 0),
             (2, 1),
             (2, 2),
+        ]
+
+    def test_start_stop_multishot(self):
+        """Multi-shot with wind_range(start, stop) restores position correctly."""
+        choose: Effect[[], int] = effect("choose")
+        h: Handler[list[int]] = create_handler(choose)
+
+        @h.on(choose)
+        def _choose(k: Resume[int, list[int]]):
+            return k(100) + k(200)
+
+        def run() -> list[int]:
+            total = 0
+            with wind_range(5, 8) as r:
+                for i in r:
+                    if i == 6:
+                        total += choose()
+                    else:
+                        total += i
+            return [total]
+
+        result = h(run)
+        # range(5,8) = [5,6,7]. choose at i=6, total=5 at that point.
+        # Shot 1: 5 + 100 + 7 = 112
+        # Shot 2: 5 + 200 + 7 = 212
+        assert result == [112, 212]
+
+    def test_step_multishot(self):
+        """Multi-shot with wind_range(start, stop, step) restores correctly."""
+        choose: Effect[[], int] = effect("choose")
+        h: Handler[list[tuple[int, ...]]] = create_handler(choose)
+
+        @h.on(choose)
+        def _choose(k: Resume[int, list[tuple[int, ...]]]):
+            return k(0) + k(1)
+
+        def run() -> list[tuple[int, ...]]:
+            choices: tuple[int, ...] = ()
+            with wind_range(0, 6, 2) as r:
+                for _ in r:
+                    v = choose()
+                    choices = choices + (v,)
+            return [choices]
+
+        result = h(run)
+        # range(0,6,2) = [0,2,4], 3 iterations, 2^3 = 8 leaves
+        assert result == [
+            (0, 0, 0), (0, 0, 1), (0, 1, 0), (0, 1, 1),
+            (1, 0, 0), (1, 0, 1), (1, 1, 0), (1, 1, 1),
         ]
 
     def test_loop_index_available(self):

--- a/uv.lock
+++ b/uv.lock
@@ -8,7 +8,7 @@ resolution-markers = [
 
 [[package]]
 name = "aleff"
-version = "0.1.0"
+version = "0.2.0"
 source = { editable = "." }
 dependencies = [
     { name = "greenlet" },

--- a/uv.lock
+++ b/uv.lock
@@ -8,7 +8,7 @@ resolution-markers = [
 
 [[package]]
 name = "aleff"
-version = "0.2.0"
+version = "0.3.0"
 source = { editable = "." }
 dependencies = [
     { name = "greenlet" },


### PR DESCRIPTION
## Summary

- Add `wind` context manager for dynamic extent guards (before/after thunks across multi-shot continuations)
- Add `wind_range` for multi-shot-safe `for` loop iteration with `range()`-compatible interface
- Add `WindBase` abstract base class with snapshot/restore mechanism
- Add `Wind` and `Ref` protocols
- Windows build support and CI improvements (from v0.2.0)

## Commits

- `b05a6cb` bump version to 0.3.0
- `d76f30d` Merge pull request #30 (Implement dynamic wind #29)
- `dbc056f` update uv.lock
- `e03f3da` upgrade cibuildwheel from v2.23 to v3.4.1
- `0aab752` upgrade build toolchains for C23 nullptr support
- `8fa016a` update README installation and development sections
- `187162c` restrict CI pull_request trigger to main and dev branches
- `f3a97de` bump version to 0.2.0 and update classifiers
- `13b8117` Merge pull request #25 (Windows build support #1)
- `bf287f3` Merge pull request #24 (Windows build support #1)
- `434a3fd` Merge pull request #23 (CI/CD #18)
- and earlier commits

## Test plan

- [x] 425 tests passing (Python 3.12)
- [x] Example regression tests passing
- [x] Pyright type checking