### PR TITLE
Release v0.3.1

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -41,6 +41,8 @@ jobs:
       - uses: actions/checkout@v6
 
       - uses: astral-sh/setup-uv@v8.0.0
+        with:
+          cache-suffix: sdist
 
       - name: Build sdist
         run: uv build --sdist

--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@ Algebraic effects for Python — deep and shallow, stateful, composable, multi-s
 
 - **Deep handlers** — effects propagate through nested function calls without annotation
 - **Shallow handlers** — handle an effect once, then delegate re-installation to the handler function; enables state machines, shift0/reset0, and strategy changes between invocations
-- **Stateful handlers** — handler functions can execute code after `resume`, enabling patterns like transactions and reverse-mode AD
+- **Stateful handlers** — handlers can maintain and update state across multiple effect invocations, either via mutable variables (deep) or re-installation with new state (shallow); enables get/put state, transactions, and reverse-mode AD
 - **Multi-shot continuations** — `resume` can be called multiple times in a single handler, enabling backtracking search, non-determinism, and other advanced patterns
 - **Sync and async** — both synchronous (`Handler`) and asynchronous (`AsyncHandler`) handlers are supported, with transparent bridging between the two
 - **Effect composition** — handler functions can perform effects themselves, dispatched to enclosing handlers; enables layered architectures and modular effect stacking
@@ -143,7 +143,6 @@ log: list[str] = []
 def run() -> list[int]:
     with wind(lambda: log.append("before"), lambda: log.append("after")):
         return [choose() * 10]
-    assert False, "unreachable"
 
 result = h(run)
 print(result)  # [10, 20]
@@ -178,7 +177,7 @@ Effects are declared as typed values and invoked like regular function calls. A 
 
 Because handlers use greenlets (not exceptions), the control flow is:
 - **Transparent** — no `yield`, `await`, or special syntax in business logic
-- **Stateful** — code after `resume` runs after the rest of the computation completes, enabling reverse-order execution (useful for backpropagation, transactions, etc.)
+- **Non-stack-cutting** — code after `resume` in the handler runs after the continuation completes, enabling reverse-order execution (useful for backpropagation, transactions, etc.)
 
 Multi-shot continuations are implemented via a CPython C extension (`aleff._multishot.v1._aleff`) that snapshots and restores interpreter frame chains.
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -70,7 +70,6 @@ line-length = 120
 [tool.cibuildwheel]
 build = ["cp312-*", "cp313-*", "cp314-*"]
 skip = ["*-manylinux_i686", "*-musllinux_*", "*-win32", "cp313t-*"]
-enable = ["cpython-freethreading"]
 build-frontend = "build[uv]"
 test-command = "pytest {project}/tests -q"
 test-requires = ["pytest", "pytest-asyncio", "greenlet>=3.3.2"]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "aleff"
-version = "0.3.0"
+version = "0.3.1"
 description = "Algebraic effects for Python — deep and shallow, stateful, composable, multi-shot handlers"
 readme = "README.md"
 license = "Apache-2.0"

--- a/src/aleff/_multishot/v1/handlers.py
+++ b/src/aleff/_multishot/v1/handlers.py
@@ -55,8 +55,8 @@ def create_async_handler(*effects: Effect[..., Any], shallow: bool = False) -> A
 #   dead   → multi-shot: restore_continuation(snapshot, value) in new greenlet
 #
 # A fresh Resume is created at each effect dispatch in _drive/_drive_async,
-# capturing the current caller_gl and snapshot. This avoids statefulness
-# and prevents infinite recursion on multi-shot.
+# capturing the current caller_gl and snapshot. This avoids carrying
+# mutable state across dispatches and prevents infinite recursion on multi-shot.
 ##
 
 

--- a/tests/test_multishot.py
+++ b/tests/test_multishot.py
@@ -308,11 +308,11 @@ class TestMultiShotDeepCalls:
 
 
 # ---------------------------------------------------------------------------
-# Multi-shot: stateful handler (post-resume code)
+# Multi-shot: post-resume code (non-stack-cutting)
 # ---------------------------------------------------------------------------
 
 
-class TestMultiShotStatefulHandler:
+class TestMultiShotPostResume:
     def test_post_resume_code_runs_per_shot(self):
         """Code after k() in the handler runs for each shot independently."""
         choose: Effect[[], int] = effect("choose")


### PR DESCRIPTION
## Summary

- Fix misleading "stateful" terminology in README, comments, and tests
- Remove deprecated `cpython-freethreading` from cibuildwheel enable (free-threading is default for CPython 3.14 in cibuildwheel v3.4.1)
- Add `cache-suffix` to `build-sdist` job to avoid uv cache contention with `build-wheels (ubuntu-latest)`

## Commits

- `6e85378` add cache-suffix to build-sdist to avoid uv cache contention
- `4ee31e7` remove deprecated cpython-freethreading from cibuildwheel enable
- `3506219` fix misleading "stateful" terminology in docs, comments, and tests
- `3050e35` bump version to 0.3.1

## Test plan

- [x] 425 tests passing
- [x] Example regression tests passing