### PR TITLE
Add cp314t free-threaded wheel builds

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -68,7 +68,7 @@ where = ["src"]
 line-length = 120
 
 [tool.cibuildwheel]
-build = ["cp312-*", "cp313-*", "cp314-*"]
+build = ["cp312-*", "cp313-*", "cp314-*", "cp314t-*"]
 skip = ["*-manylinux_i686", "*-musllinux_*", "*-win32", "cp313t-*"]
 build-frontend = "build[uv]"
 test-command = "pytest {project}/tests -q"


### PR DESCRIPTION
## Summary

Add `cp314t-*` to cibuildwheel build targets to produce free-threaded CPython 3.14 wheels.

`cp314-*` does not match `cp314t-*` (different identifier prefix). In cibuildwheel v3.4.1, `cp314t` identifiers are available by default without `enable = ["cpython-freethreading"]` (which is deprecated), but must be explicitly included in the `build` pattern.

## Commits

- `7df4494` add cp314t-* to cibuildwheel build targets for free-threaded wheels

## Test plan

- [ ] Verify `cp314t` wheels appear in publish workflow output