### PR TITLE
Add doc links to README and fix docs workflow

### DIFF
--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -28,7 +28,7 @@ jobs:
       - name: Build documentation
         run: uv run sphinx-build -b html docs/source docs/build
 
-      - uses: actions/upload-pages-artifact@v3
+      - uses: actions/upload-pages-artifact@v4
         with:
           path: docs/build
 

--- a/README.md
+++ b/README.md
@@ -2,6 +2,8 @@
 
 Algebraic effects for Python — deep and shallow, stateful, composable, multi-shot handlers.
 
+[Doc](https://hnmr293.github.io/aleff/) | [PyPI](https://pypi.org/project/aleff/) | [GitHub](https://github.com/hnmr293/aleff)
+
 ```python
 from aleff import effect, create_handler
 


### PR DESCRIPTION
## Summary

- Add Doc/PyPI/GitHub links to README header
- Upgrade `upload-pages-artifact` from v3 to v4 (Node.js 20 deprecation)

## Commits

- `dab995e` add doc links to README and upgrade upload-pages-artifact to v4

## Test plan

- [x] 425 tests passing
- [x] Docs workflow deploys successfully