### PR TITLE
fix: make multi-shot rewind re-entry-only

### DIFF
--- a/src/aleff/_multishot/v1/winds.py
+++ b/src/aleff/_multishot/v1/winds.py
@@ -95,8 +95,13 @@ class WindBase[T, S](ABC):
         Default: no-op.
     """
 
+    def __init__(self) -> None:
+        # Number of times this entry has been entered without a matching exit.
+        # Nesting the same object is allowed, so this is a depth, not a flag.
+        self._wind_depth = 0
+
     def __enter__(self) -> T:
-        result = self._wind_enter()
+        result = self._enter_extent()
         _push_wind_entry(self)
         return result
 
@@ -106,8 +111,32 @@ class WindBase[T, S](ABC):
         exc_value: BaseException | None,
         traceback: Any,
     ) -> bool:
+        # Checked before the pop so that an unbalanced __exit__ is reported as
+        # such instead of corrupting the stack (or failing inside pop).
+        self._check_active()
         _pop_wind_entry()
-        return self._wind_exit(exc_type, exc_value, traceback)
+        return self._exit_extent(exc_type, exc_value, traceback)
+
+    def _enter_extent(self) -> T:
+        """Enter the dynamic extent, tracking the enter/exit balance."""
+        result = self._wind_enter()
+        self._wind_depth += 1
+        return result
+
+    def _exit_extent(
+        self,
+        exc_type: type[BaseException] | None = None,
+        exc_val: BaseException | None = None,
+        exc_tb: TracebackType | None = None,
+    ) -> bool:
+        """Exit the dynamic extent, tracking the enter/exit balance."""
+        self._check_active()
+        self._wind_depth -= 1
+        return self._wind_exit(exc_type, exc_val, exc_tb)
+
+    def _check_active(self) -> None:
+        if self._wind_depth <= 0:
+            raise RuntimeError("wind exit without active entry")
 
     @abstractmethod
     def _wind_enter(self) -> T: ...
@@ -139,57 +168,45 @@ class WindBase[T, S](ABC):
         return [_CapturedWindEntry(entry, entry._wind_snapshot()) for entry in entries]
 
     @staticmethod
-    def _rewind(
-        from_winds: list["WindBase[Any, Any]"],
-        to_winds: "_CapturedWinds",
-    ) -> None:
-        """Transition the wind stack from *from_winds* to *to_winds*.
+    def _rewind(to_winds: "_CapturedWinds") -> None:
+        """Re-enter the captured dynamic extents in the current context.
 
-        Called by :func:`rewind` during multi-shot continuation re-entry.
-        The two stacks may share a common prefix (same ``WindBase`` objects
-        at the same positions).  Entries in the common prefix are left
-        untouched — only the differing tails are unwound / rewound.
+        Called by :func:`rewind` at the start of a multi-shot re-entry, from
+        inside a freshly created greenlet whose context was copied from the
+        *invoker* of ``k()`` — the handler.  The wind stack visible here
+        therefore describes the handler's branch of the dynamic tree, not the
+        continuation's.  ``k()`` returns to the handler, so that branch stays
+        active: nothing is ever unwound here.
 
-        Steps:
+        The two branches share a prefix — the extents established outside the
+        handler boundary.  Those are already active and must not be entered
+        twice.  Entries below the shared prefix belong to the captured branch
+        alone and are entered outermost first, each preceded by
+        ``_wind_restore(snapshot)`` to restore the state captured at
+        continuation capture time.
 
-        1. Find the longest common prefix by identity (``is``) comparison.
-        Shared entries represent dynamic extents that are active in both
-        the current context and the captured context.
-        2. Unwind entries leaving: call ``_wind_exit()`` on entries in
-        *from_winds* beyond the common prefix, innermost first (reversed).
-        3. Rewind entries entering: for each entry in *to_winds* beyond the
-        common prefix, call ``_wind_restore(snapshot)`` to restore the
-        state captured at continuation capture time, then ``_wind_enter()``
-        to re-enter the dynamic extent.
-        4. Replace the wind stack with the entry list from *to_winds*.
+        Finally the stack is replaced by the captured entries, so a nested
+        capture inside the resumed continuation cannot observe the handler's.
         """
 
         to_entries = [item.entry for item in to_winds]
+        shared = _shared_prefix_len(_get_wind_stack(), to_entries)
 
-        # 1. find the longest common prefix
-        n = min(len(from_winds), len(to_entries))
-        common = 0
-        for i in range(n):
-            if from_winds[i] is to_entries[i]:
-                common = i + 1
-            else:
-                break
+        entered: list[WindBase[Any, Any]] = []
+        try:
+            for item in to_winds[shared:]:
+                item.entry._wind_restore(item.snapshot)
+                item.entry._enter_extent()
+                entered.append(item.entry)
+        except BaseException:
+            # _rewind runs before restore_continuation(), so there is no Python
+            # frame yet whose __exit__ would unwind these on propagation.
+            # Undo them here, innermost first, or the extents are lost.
+            for entry in reversed(entered):
+                entry._exit_extent()
+            raise
 
-        exiting = from_winds[common:]
-        entering = to_winds[common:]
-
-        # 2. Unwind: exit extents we are leaving (innermost first).
-        for entry in reversed(exiting):
-            entry._wind_exit()
-
-        # 3. Rewind: restore snapshot then enter extents we are entering (outermost first).
-        for item in entering:
-            entry, snapshot = item.entry, item.snapshot
-            entry._wind_restore(snapshot)
-            entry._wind_enter()
-
-        # 4. Set the wind stack to the target state.
-        _set_wind_stack(list(to_entries))
+        _set_wind_stack(to_entries)
 
 
 class _Wind[T](WindBase[Ref[T], None]):
@@ -216,6 +233,7 @@ class _Wind[T](WindBase[Ref[T], None]):
         *,
         auto_exit: bool = True,
     ) -> None:
+        super().__init__()
         self._before = before
         self._after = after
         self._auto_exit = auto_exit
@@ -223,8 +241,10 @@ class _Wind[T](WindBase[Ref[T], None]):
         self._ref: _Ref[T] | None = None  # lifetime: ~_Wind
 
     def _wind_enter(self) -> Ref[T]:
-        # In the normal lifecycle, _wind_exit (via __exit__ or _do_winds unwinding) always clears _item before _wind_enter is called again.
-        # A non-None _item here means the wind stack management has a bug — either __exit__ was skipped or _do_winds failed to unwind properly.
+        # A single _cm slot means an auto_exit guard cannot be nested inside
+        # itself.  WindBase already tracks the enter/exit balance, so a live
+        # _cm here means the same object was re-entered — not that an exit
+        # was skipped.
         if self._cm is not None:
             raise RuntimeError("wind entry already active")
 
@@ -243,8 +263,8 @@ class _Wind[T](WindBase[Ref[T], None]):
         exc_val: BaseException | None = None,
         exc_tb: TracebackType | None = None,
     ) -> bool:
-        if self._ref is None:
-            raise RuntimeError("wind exit without active entry")
+        # WindBase tracks the enter/exit balance, so _wind_enter has run.
+        assert self._ref is not None
 
         suppress = False
         value = self._ref.unwrap()
@@ -313,6 +333,7 @@ class wind_range(WindBase["wind_range", int]):
     def __init__(self, start: int, stop: int, step: int = 1, /) -> None: ...
 
     def __init__(self, start: int, stop: int | None = None, step: int = 1) -> None:
+        super().__init__()
         if stop is None:
             # wind_range(stop) form: start=0, stop=start
             start, stop = 0, start
@@ -388,8 +409,25 @@ def capture_wind_stack(caller_gl: gl.greenlet) -> _CapturedWinds:
 
 # for handlers.py
 def rewind(captured: _CapturedWinds) -> None:
-    """Transition from the current wind stack to *captured*."""
-    WindBase._rewind(_get_wind_stack(), captured)  # pyright: ignore[reportPrivateUsage]
+    """Re-enter the *captured* dynamic extents for a multi-shot continuation."""
+    WindBase._rewind(captured)  # pyright: ignore[reportPrivateUsage]
+
+
+def _shared_prefix_len(
+    current: list[WindBase[Any, Any]],
+    captured: list[WindBase[Any, Any]],
+) -> int:
+    """Length of the deepest common ancestor of two dynamic-extent paths.
+
+    A wind stack is the path from the dynamic root to a dynamic point, so the
+    longest common prefix (by identity) is the extents both paths are inside.
+    """
+    n = 0
+    for a, b in zip(current, captured):
+        if a is not b:
+            break
+        n += 1
+    return n
 
 
 def _get_wind_stack() -> list[WindBase[Any, Any]]:

--- a/tests/test_dynamic_wind.py
+++ b/tests/test_dynamic_wind.py
@@ -7,15 +7,24 @@ wind(before, after, *, auto_exit=True) establishes a dynamic extent guard:
 - The return value of before() is wrapped in a Ref for multi-shot safety
 """
 
+import asyncio
+from contextlib import contextmanager
+from typing import Any, Iterator
+
 import pytest
+import pytest_asyncio  # pyright: ignore[reportUnusedImport]
 
 from aleff import (
     effect,
     Effect,
     Resume,
+    ResumeAsync,
     Handler,
+    AsyncHandler,
     create_handler,
+    create_async_handler,
     wind,
+    wind_range,
     Ref,
 )
 from aleff._multishot.v1.winds import _get_wind_stack  # pyright: ignore[reportPrivateUsage]
@@ -974,3 +983,432 @@ class TestRefCornerCases:
         # Both shots should see the same Ref object (heap-shared)
         assert len(ref_ids) == 2
         assert ref_ids[0] == ref_ids[1]
+
+
+# ---------------------------------------------------------------------------
+# Handler-side dynamic extents must survive multi-shot re-entry (#36)
+#
+# A multi-shot resume runs the continuation in a fresh greenlet whose context
+# is copied from the *invoker* of k() -- the handler.  The wind entries visible
+# there belong to the handler's branch of the dynamic tree, not to the
+# continuation's.  k() returns to the handler, so that branch stays active and
+# must never be unwound by the re-entry.
+# ---------------------------------------------------------------------------
+
+
+class TestWindHandlerExtentIsolation:
+    def test_wind_inside_handler_fn_two_shots(self):
+        """A wind in the handler fn pairs 1:1 when k is resumed twice."""
+        e: Effect[[], int] = effect("e")
+        h: Handler[int] = create_handler(e)
+
+        log: list[str] = []
+
+        @h.on(e)
+        def _handle(k: Resume[int, int]) -> int:
+            with wind(lambda: log.append("before"), lambda: log.append("after")):
+                return k(1) + k(2)
+
+        def body() -> int:
+            log.append("body start")
+            v = e()
+            log.append(f"body v={v}")
+            return v
+
+        assert h(body) == 3
+        assert log == ["body start", "before", "body v=1", "body v=2", "after"]
+        assert _get_wind_stack() == []
+
+    def test_wind_inside_handler_fn_three_shots(self):
+        """The extra after() must not scale with the number of shots."""
+        e: Effect[[], int] = effect("e")
+        h: Handler[int] = create_handler(e)
+
+        log: list[str] = []
+
+        @h.on(e)
+        def _handle(k: Resume[int, int]) -> int:
+            with wind(lambda: log.append("before"), lambda: log.append("after")):
+                return k(1) + k(2) + k(3)
+
+        assert h(lambda: e()) == 6
+        assert log.count("before") == 1
+        assert log.count("after") == 1
+        assert log[-1] == "after"
+        assert _get_wind_stack() == []
+
+    def test_nested_wind_inside_handler_fn_multishot(self):
+        """Nested handler-side winds unwind innermost-first, exactly once."""
+        e: Effect[[], int] = effect("e")
+        h: Handler[int] = create_handler(e)
+
+        log: list[str] = []
+
+        @h.on(e)
+        def _handle(k: Resume[int, int]) -> int:
+            with wind(lambda: log.append("before(outer)"), lambda: log.append("after(outer)")):
+                with wind(lambda: log.append("before(inner)"), lambda: log.append("after(inner)")):
+                    return k(1) + k(2)
+
+        assert h(lambda: e()) == 3
+        assert log == [
+            "before(outer)",
+            "before(inner)",
+            "after(inner)",
+            "after(outer)",
+        ]
+        assert _get_wind_stack() == []
+
+    def test_wind_in_caller_and_handler_multishot(self):
+        """Caller-side and handler-side extents are independent under multi-shot."""
+        e: Effect[[], int] = effect("e")
+        h: Handler[int] = create_handler(e)
+
+        log: list[str] = []
+
+        @h.on(e)
+        def _handle(k: Resume[int, int]) -> int:
+            with wind(lambda: log.append("before(H)"), lambda: log.append("after(H)")):
+                return k(1) + k(2)
+
+        def body() -> int:
+            with wind(lambda: log.append("before(C)"), lambda: log.append("after(C)")):
+                v = e()
+                log.append(f"v={v}")
+                return v
+
+        assert h(body) == 3
+        # The caller's extent is re-entered per shot; the handler's is not.
+        assert log == [
+            "before(C)",
+            "before(H)",
+            "v=1",
+            "after(C)",
+            "before(C)",
+            "v=2",
+            "after(C)",
+            "after(H)",
+        ]
+        assert _get_wind_stack() == []
+
+    def test_escaping_continuation_under_unrelated_wind(self):
+        """An escaped k() must not unwind a wind it knows nothing about.
+
+        No handler-side wind is involved here: the continuation is stored by the
+        handler, h() returns, and k is then invoked from inside an unrelated
+        dynamic extent at top level.
+        """
+        e: Effect[[], int] = effect("e")
+        h: Handler[int] = create_handler(e)
+
+        log: list[str] = []
+        saved: list[Resume[int, int]] = []
+
+        @h.on(e)
+        def _handle(k: Resume[int, int]) -> int:
+            saved.append(k)
+            return 0
+
+        assert h(lambda: e()) == 0
+
+        with wind(lambda: log.append("before"), lambda: log.append("after")):
+            assert saved[0](99) == 99
+
+        assert log == ["before", "after"]
+        assert _get_wind_stack() == []
+
+    def test_nested_multishot_does_not_unwind_rewound_wind(self):
+        """An inner resume must not unwind what an outer rewind re-entered."""
+        inner_e: Effect[[], int] = effect("inner")
+        outer_e: Effect[[int], int] = effect("outer")
+
+        h_outer: Handler[Any] = create_handler(outer_e)
+        h_inner: Handler[Any] = create_handler(inner_e)
+
+        log: list[str] = []
+
+        @h_outer.on(outer_e)
+        def _handle_outer(k: Resume[int, Any], v: int) -> list[Any]:
+            return [k(v), k(v + 100)]
+
+        @h_inner.on(inner_e)
+        def _handle_inner(k: Resume[int, Any]) -> Any:
+            with wind(lambda: log.append("before"), lambda: log.append("after")):
+                return k(outer_e(7))
+
+        h_outer(lambda: h_inner(lambda: inner_e()))
+
+        # The outer handler drives the inner handler fn twice, so the guard is
+        # entered twice -- and must be exited exactly twice.
+        assert log.count("before") == 2
+        assert log.count("after") == 2
+        assert log == ["before", "after", "before", "after"]
+        assert _get_wind_stack() == []
+
+    def test_recursive_multishot_wind_in_handler(self):
+        """Recursive multi-shot must not amplify the handler-side after()."""
+        choose: Effect[[list[int]], int] = effect("choose")
+        h: Handler[Any] = create_handler(choose)
+
+        log: list[str] = []
+        first = [True]
+
+        @h.on(choose)
+        def _choose(k: Resume[int, Any], opts: list[int]) -> list[Any]:
+            if first[0]:
+                first[0] = False
+                with wind(lambda: log.append("before"), lambda: log.append("after")):
+                    return [k(o) for o in opts]
+            return [k(o) for o in opts]
+
+        def body() -> int:
+            a = choose([1, 2])
+            b = choose([10, 20])
+            return a + b
+
+        h(body)
+        assert log == ["before", "after"]
+        assert _get_wind_stack() == []
+
+    def test_wind_outside_handler_invocation_multishot(self):
+        """A wind wrapping h(...) is shared, so it is neither re-entered nor exited.
+
+        Regression guard: a fix that simply clears the re-entry greenlet's wind
+        stack would re-enter this extent once per shot.
+        """
+        e: Effect[[], int] = effect("e")
+        h: Handler[int] = create_handler(e)
+
+        log: list[str] = []
+
+        @h.on(e)
+        def _handle(k: Resume[int, int]) -> int:
+            return k(1) + k(2)
+
+        def run() -> int:
+            with wind(lambda: log.append("before"), lambda: log.append("after")):
+                return h(lambda: e())
+
+        assert run() == 3
+        assert log == ["before", "after"]
+        assert _get_wind_stack() == []
+
+    def test_wind_range_inside_handler_fn_multishot(self):
+        """A handler-side wind_range keeps its position across shots.
+
+        Its snapshot belongs to the handler's branch and must never be restored
+        by a continuation re-entry, which would rewind the loop.
+        """
+        e: Effect[[], int] = effect("e")
+        h: Handler[int] = create_handler(e)
+
+        seen: list[int] = []
+
+        @h.on(e)
+        def _handle(k: Resume[int, int]) -> int:
+            total = 0
+            with wind_range(3) as r:
+                for i in r:
+                    seen.append(i)
+                    total += k(i)
+            return total
+
+        assert h(lambda: e()) == 0 + 1 + 2
+        assert seen == [0, 1, 2]
+        assert _get_wind_stack() == []
+
+    def test_cm_resource_stays_open_across_shots_in_handler(self):
+        """An auto_exit resource in the handler fn is not released between shots."""
+        e: Effect[[], int] = effect("e")
+        h: Handler[int] = create_handler(e)
+
+        log: list[str] = []
+
+        @contextmanager
+        def resource() -> Iterator[dict[str, bool]]:
+            log.append("open")
+            state = {"closed": False}
+            try:
+                yield state
+            finally:
+                state["closed"] = True
+                log.append("close")
+
+        closed_after_shot: list[bool] = []
+
+        @h.on(e)
+        def _handle(k: Resume[int, int]) -> int:
+            with wind(resource) as ref:
+                a = k(1)
+                closed_after_shot.append(ref.unwrap()["closed"])
+                b = k(2)
+                closed_after_shot.append(ref.unwrap()["closed"])
+                return a + b
+
+        assert h(lambda: e()) == 3
+        # The resource must still be usable inside the with block after every shot.
+        assert closed_after_shot == [False, False]
+        assert log == ["open", "close"]
+        assert _get_wind_stack() == []
+
+    def test_exception_in_later_shot_with_handler_wind(self):
+        """after() runs once when a later shot raises out of the continuation."""
+        e: Effect[[], int] = effect("e")
+        h: Handler[int] = create_handler(e)
+
+        log: list[str] = []
+
+        @h.on(e)
+        def _handle(k: Resume[int, int]) -> int:
+            with wind(lambda: log.append("before"), lambda: log.append("after")):
+                k(1)
+                return k(2)
+
+        def body() -> int:
+            v = e()
+            if v == 2:
+                raise ValueError("boom")
+            return v
+
+        with pytest.raises(ValueError, match="boom"):
+            h(body)
+
+        assert log == ["before", "after"]
+        assert _get_wind_stack() == []
+
+
+class TestWindAsyncHandlerExtentIsolation:
+    @pytest.mark.asyncio
+    async def test_wind_inside_async_handler_fn_multishot(self):
+        """The async re-entry path has the same isolation requirement."""
+        e: Effect[[], int] = effect("e")
+        h: AsyncHandler[int] = create_async_handler(e)
+
+        log: list[str] = []
+
+        @h.on(e)
+        async def _handle(k: ResumeAsync[int, int]) -> int:
+            with wind(lambda: log.append("before"), lambda: log.append("after")):
+                return await k(1) + await k(2) + await k(3)
+
+        assert await h(lambda: e()) == 6
+        assert log == ["before", "after"]
+        assert _get_wind_stack() == []
+
+    @pytest.mark.asyncio
+    async def test_wind_in_async_caller_and_handler_multishot(self):
+        """Caller-side extents still rewind per shot under an async handler."""
+        e: Effect[[], int] = effect("e")
+        h: AsyncHandler[int] = create_async_handler(e)
+
+        log: list[str] = []
+
+        @h.on(e)
+        async def _handle(k: ResumeAsync[int, int]) -> int:
+            with wind(lambda: log.append("before(H)"), lambda: log.append("after(H)")):
+                return await k(1) + await k(2)
+
+        def body() -> int:
+            with wind(lambda: log.append("before(C)"), lambda: log.append("after(C)")):
+                return e()
+
+        assert await h(body) == 3
+        assert log == [
+            "before(C)",
+            "before(H)",
+            "after(C)",
+            "before(C)",
+            "after(C)",
+            "after(H)",
+        ]
+        assert _get_wind_stack() == []
+
+
+# ---------------------------------------------------------------------------
+# Rewind failure handling
+#
+# rewind() runs before restore_continuation(), so no Python frame exists yet
+# that would __exit__ the extents it has just re-entered.  If a before() raises
+# part-way through, the re-entry must undo itself or those extents are lost.
+# ---------------------------------------------------------------------------
+
+
+class TestWindRewindRollback:
+    def test_before_raising_on_reentry_unwinds_partial_extents(self):
+        """A before() that raises mid-rewind must not orphan the outer extent."""
+        e: Effect[[], int] = effect("e")
+        h: Handler[int] = create_handler(e)
+
+        log: list[str] = []
+        calls = {"n": 0}
+
+        def flaky_before() -> None:
+            calls["n"] += 1
+            log.append(f"before(inner)#{calls['n']}")
+            if calls["n"] == 2:
+                raise RuntimeError("inner before failed")
+
+        outer = wind(lambda: log.append("before(outer)"), lambda: log.append("after(outer)"))
+        inner = wind(flaky_before, lambda: log.append("after(inner)"))
+
+        @h.on(e)
+        def _handle(k: Resume[int, int]) -> int:
+            return k(1) + k(2)
+
+        def body() -> int:
+            with outer:
+                with inner:
+                    return e()
+
+        with pytest.raises(RuntimeError, match="inner before failed"):
+            h(body)
+
+        assert log == [
+            "before(outer)",
+            "before(inner)#1",
+            "after(inner)",
+            "after(outer)",
+            # second shot: outer is re-entered, inner's before() then fails
+            "before(outer)",
+            "before(inner)#2",
+            # the re-entered outer extent must be unwound, not lost
+            "after(outer)",
+        ]
+        assert log.count("before(outer)") == log.count("after(outer)")
+        assert _get_wind_stack() == []
+
+
+# ---------------------------------------------------------------------------
+# enter/exit pairing is enforced by WindBase
+# ---------------------------------------------------------------------------
+
+
+class TestWindPairingGuard:
+    def test_exit_without_entry_raises(self):
+        """__exit__ on a wind that was never entered is an error."""
+        w = wind(lambda: None, lambda: None)
+        with pytest.raises(RuntimeError, match="wind exit without active entry"):
+            w.__exit__(None, None, None)
+
+    def test_exit_more_times_than_entered_raises(self):
+        """A second __exit__ after a balanced with-block is an error."""
+        w = wind(lambda: None, lambda: None)
+        with w:
+            pass
+        with pytest.raises(RuntimeError, match="wind exit without active entry"):
+            w.__exit__(None, None, None)
+        assert _get_wind_stack() == []
+
+    def test_same_wind_object_can_nest(self):
+        """Recursive reuse of one wind object keeps working (no auto_exit cm)."""
+        log: list[str] = []
+        w = wind(lambda: log.append("before"), lambda: log.append("after"))
+
+        def rec(n: int) -> None:
+            with w:
+                if n:
+                    rec(n - 1)
+
+        rec(2)
+        assert log == ["before"] * 3 + ["after"] * 3
+        assert _get_wind_stack() == []

--- a/tests/test_dynamic_wind.py
+++ b/tests/test_dynamic_wind.py
@@ -7,7 +7,6 @@ wind(before, after, *, auto_exit=True) establishes a dynamic extent guard:
 - The return value of before() is wrapped in a Ref for multi-shot safety
 """
 
-import asyncio
 from contextlib import contextmanager
 from typing import Any, Iterator
 


### PR DESCRIPTION
Closes #36.

## Root cause

`rewind()` runs inside a freshly created greenlet whose context is copied from
the *invoker* of `k()` — the handler (`handlers.py:136-137` sync,
`handlers.py:186-187` async). The wind stack visible there describes the
**handler's** branch of the dynamic tree. The captured stack, read from
`caller_gl.gr_context` (`winds.py:130-139`), describes the **continuation's**.

`_rewind` treated the two as one series and unwound the difference
(`winds.py:182-183`). Those two stacks are sibling branches, so
`from_winds[common:]` was by construction exactly the set of extents the
handler still holds — and `k()` returns to the handler, so they must not be
exited.

The unwind step was therefore not conditionally wrong; reaching it at all was
wrong. Existing tests never reached it: instrumenting the suite showed
`_rewind` called 204 times with a non-empty `exiting` **0 times**.

## Not one bug, five

The same line produced five independently reproducible shapes:

| | Trigger | Observed |
|---|---|---|
| 1a | guard in the handler fn, `k` resumed 3x (the reported case) | `before` 1, `after` 3 |
| 1b | escaped continuation invoked under an *unrelated* guard | `before` 1, `after` 2 |
| 1c | nested multi-shot: inner resume unwinds what the outer rewind re-entered | `before` 2, `after` 3 |
| 1d | async handler, same as 1a | `before` 1, `after` 3 |
| 1e | recursive multi-shot (`amb`) — amplified, not merely doubled | `before` 1, `after` 4 |

1b involves no handler-side guard at all, which rules out "the handler's `wind`
is a special case".

With `auto_exit`, the duplicate exit is **invisible in logs** — `_cm` is
cleared at `winds.py:266`, so the second `after` is silent — while the guarded
resource is released mid-block. That turns a logging oddity into a
use-after-release.

## Changes

**Drop the unwind step.** `rewind()` is re-entry-only. The shared-prefix check
stays, so extents established outside the handler boundary are neither
re-entered nor exited (`test_shared_outer_extent` depends on this). The stack
is still replaced wholesale, which nested multi-shot needs: otherwise a capture
inside the resumed continuation would see the handler's entries.

`from_winds` is gone from `_rewind`'s signature. "Where we came from" was never
a caller's choice — it is a premise of the function, and taking it as a
parameter is what made the misuse expressible.

**Roll back partial re-entry.** If a `before()` raises part-way through,
already-re-entered extents were orphaned outright. `rewind()` runs *before*
`restore_continuation()`, so no Python frame exists yet whose `__exit__` would
unwind them on propagation — unlike the unwind step, this was a loss, not a
duplication.

**Track the enter/exit balance in `WindBase`.** The old guards could not detect
a double exit: `_ref` is deliberately retained across multi-shot re-entry
(`winds.py:261-266`), and the `_cm` check only applies to `auto_exit` guards
that return a context manager. Nesting one `wind` object stays legal, so the
balance is a depth rather than a flag, and the `auto_exit` self-nesting
restriction is unchanged.

## Verification

- `uv run pytest tests/` — 442 passed (425 existing + 17 new).
- `uv run pyright tests/ src/` — 0 errors, matching the baseline on `dev`.
- All five shapes plus the rollback case reproduce on `dev` and are resolved
  here, checked with a standalone script outside the suite.
- 14 of the 17 new tests fail at the test-only commit. The 3 that pass are
  deliberate regression guards: a guard wrapping `h(...)` must stay shared, a
  handler-side `wind_range` must keep its position, and one `wind` object must
  still nest recursively.

## Out of scope

Found during the same investigation, filed separately:

- #37 — the caller's `after` never runs when the handler *raises* without
  resuming (fixed in a separate `dev`-based PR; no file overlap with this one,
  and the two merge cleanly).
- #38 — `after` is truncated when it performs an effect during an abort. Needs
  a specification decision, not a bug fix.
- #39, #40 — async defects unrelated to `wind`.

## Commits

- `15e4da9` test: add failing tests for unpaired wind on multi-shot re-entry #36
- `00e4a6e` fix: make multi-shot rewind re-entry-only #36
