### PR TITLE
fix: abort the caller when the handler does not return normally

### DIFF
--- a/src/aleff/_multishot/v1/handlers.py
+++ b/src/aleff/_multishot/v1/handlers.py
@@ -239,8 +239,24 @@ def _drive[V](caller_gl: Any, value: V | EffectContext[..., Any]) -> V:
 
     # effect performed
     # switch to the handler greenlet
+    #
+    # From here the caller is suspended mid-effect.  Whatever happens next --
+    # the handler returning without resuming, the handler raising, or dispatch
+    # failing outright -- it must not be left that way: its finally blocks and
+    # wind guards are still pending.  _abort_caller in the finally below makes
+    # that a single invariant of this function.
+    ctx = cast(EffectContext[..., Any], value)
+    try:
+        return _drive_effect(caller_gl, ctx)
+    finally:
+        if not caller_gl.dead:
+            debug(f"||< **abort** perform {eff_str(ctx.effect)}")
+            _abort_caller(caller_gl)
 
-    d = _pre_drive(caller_gl, cast(EffectContext[..., Any], value))
+
+def _drive_effect(caller_gl: Any, value: EffectContext[..., Any]) -> Any:
+    """Dispatch one performed effect.  The caller is suspended throughout."""
+    d = _pre_drive(caller_gl, value)
 
     if isinstance(d.handler, _AsyncHandler):
         # async handler found in sync context — relay to parent greenlet.
@@ -282,12 +298,6 @@ def _drive[V](caller_gl: Any, value: V | EffectContext[..., Any]) -> V:
     resume: Resume[Any, Any] = _Resume(caller_gl, snapshot, d.token, d.handler)
     v = d.fn(resume, *d.args, **d.kwargs)
 
-    if not caller_gl.dead:
-        # resume not called in the handler
-        # discard the result
-        debug(f"||< **abort** perform {eff_str(d.effect)} = {v!r}")
-        _abort_caller(caller_gl)
-
     debug(f"||< perform {eff_str(d.effect)} = {v!r}")
 
     debug("||< @main")
@@ -303,18 +313,29 @@ def _abort_caller(caller_gl: Any) -> None:
     blocks but is not caught by ``except Exception``.
     """
 
+    # A dying greenlet hands its exception to its *parent*, not to whoever
+    # switched into it.  Redirect the parent here so that EffectAborted -- and
+    # any exception the caller's cleanup raises -- surfaces in this greenlet
+    # rather than in whichever one happens to be caller_gl.parent.
+    # (See _Resume.__call__ for the same redirection.)
+    old_parent = caller_gl.parent
+    caller_gl.parent = gl.getcurrent()
     try:
-        abort_v = caller_gl.switch(ABORT)
-    except EffectAborted:
-        return
-    while not caller_gl.dead:
-        if isinstance(abort_v, EffectContext):
-            try:
-                abort_v = caller_gl.switch(ABORT)
-            except EffectAborted:
-                return
-        else:
-            break
+        try:
+            abort_v = caller_gl.switch(ABORT)
+        except EffectAborted:
+            return
+        while not caller_gl.dead:
+            if isinstance(abort_v, EffectContext):
+                try:
+                    abort_v = caller_gl.switch(ABORT)
+                except EffectAborted:
+                    return
+            else:
+                break
+    finally:
+        if not caller_gl.dead:
+            caller_gl.parent = old_parent
 
 
 class _AwaitRequest[V]:
@@ -439,8 +460,23 @@ async def _drive_async[V](
 
     # effect performed
     # switch to the handler greenlet
+    # See _drive for why the abort belongs in a finally.
+    ctx = cast(EffectContext[..., Any], value)
+    try:
+        return await _drive_effect_async(caller_gl, ctx, exclude_token)
+    finally:
+        if not caller_gl.dead:
+            debug(f"||< **abort** perform {eff_str(ctx.effect)}")
+            _abort_caller(caller_gl)
 
-    d = _pre_drive(caller_gl, cast(EffectContext[..., Any], value), exclude_token=exclude_token)
+
+async def _drive_effect_async(
+    caller_gl: Any,
+    value: EffectContext[..., Any],
+    exclude_token: object | None,
+) -> Any:
+    """Dispatch one performed effect.  The caller is suspended throughout."""
+    d = _pre_drive(caller_gl, value, exclude_token=exclude_token)
 
     # For shallow handlers, remove all entries before calling fn so that
     # resumed computation will not find this handler on the stack.
@@ -468,12 +504,6 @@ async def _drive_async[V](
             d.kwargs,
             _exclude,
         )
-
-    if not caller_gl.dead:
-        # resume not called in the handler
-        # discard the result
-        debug(f"||< **abort** perform {eff_str(d.effect)} = {v!r}")
-        _abort_caller(caller_gl)
 
     debug(f"||< perform {eff_str(d.effect)} = {v!r}")
 

--- a/tests/test_exception.py
+++ b/tests/test_exception.py
@@ -323,10 +323,16 @@ class TestAbortOnHandlerException:
                 missing()
                 return v
 
-        with pytest.raises(EffectNotHandledError) as excinfo:
+        # EffectNotHandledError is generic, so pytest.raises cannot type it;
+        # catch it directly and hold it for the same reason as above.
+        raised: list[BaseException] = []
+        try:
             h(caller)
+        except BaseException as ex:
+            raised.append(ex)
 
-        assert excinfo.value.__traceback__ is not None
+        assert len(raised) == 1
+        assert isinstance(raised[0], EffectNotHandledError)
         assert log == ["before", "after"]
 
     def test_nested_handler_exception_unwinds_both_callers(self):
@@ -444,7 +450,9 @@ class TestAsyncAbortOnHandlerException:
 
         log: list[str] = []
 
-        @h.on(e)
+        # An async handler accepts a sync handler fn at runtime -- it is run via
+        # _run_handler_fn_in_greenlet -- but AsyncEffectHandler requires async.
+        @h.on(e)  # pyright: ignore[reportArgumentType]
         def _handle(k: ResumeAsync[int, int]) -> int:
             raise ValueError("handler error")
 
@@ -456,6 +464,40 @@ class TestAsyncAbortOnHandlerException:
             await h(caller)
 
         assert excinfo.value.__traceback__ is not None
+        assert log == ["before", "after"]
+
+    @pytest.mark.asyncio
+    async def test_async_unhandled_effect_in_continuation_unwinds_caller(self):
+        """The abort must reach the caller across the bridge greenlet.
+
+        Here the abort is driven from the handler fn's greenlet, which is not
+        caller_gl.parent, so the unwinding exception has to be routed back to
+        the aborting greenlet rather than to the caller's original parent.
+        """
+        e: Effect[[], int] = effect("e")
+        missing: Effect[[], int] = effect("missing")
+        h: AsyncHandler[int] = create_async_handler(e)
+
+        log: list[str] = []
+
+        @h.on(e)
+        async def _handle(k: ResumeAsync[int, int]) -> int:
+            return await k(1)
+
+        def caller() -> int:
+            with wind(lambda: log.append("before"), lambda: log.append("after")):
+                v = e()
+                missing()
+                return v
+
+        raised: list[BaseException] = []
+        try:
+            await h(caller)
+        except BaseException as ex:
+            raised.append(ex)
+
+        assert len(raised) == 1
+        assert isinstance(raised[0], EffectNotHandledError)
         assert log == ["before", "after"]
 
 

--- a/tests/test_exception.py
+++ b/tests/test_exception.py
@@ -18,6 +18,7 @@ from aleff import (
     AsyncHandler,
     create_handler,
     create_async_handler,
+    wind,
     EffectNotHandledError,
 )
 
@@ -242,6 +243,220 @@ class TestAbortNoGreenletExitLeak:
 
         result = h(caller)
         assert result == 99
+
+
+# ---------------------------------------------------------------------------
+# Abort on the exception path
+#
+# A handler that returns without resuming aborts the caller, so its finally
+# blocks and wind guards run.  A handler that *raises* without resuming leaves
+# the caller suspended in exactly the same state, and owes it the same abort.
+# ---------------------------------------------------------------------------
+
+
+class TestAbortOnHandlerException:
+    def test_handler_exception_runs_caller_finally(self):
+        """A handler that raises without resuming still unwinds the caller."""
+        e: Effect[[], int] = effect("e")
+        h: Handler[int] = create_handler(e)
+
+        log: list[str] = []
+
+        @h.on(e)
+        def _handle(k: Resume[int, int]) -> int:
+            log.append("handler raises")
+            raise ValueError("handler error")
+
+        def caller() -> int:
+            try:
+                return e()
+            finally:
+                log.append("caller finally")
+
+        # Holding the traceback keeps the suspended caller greenlet alive, so
+        # this observes the abort itself rather than a collection side effect.
+        with pytest.raises(ValueError, match="handler error") as excinfo:
+            h(caller)
+        log.append("caught")
+
+        assert excinfo.value.__traceback__ is not None
+        # The caller must be unwound before the exception surfaces -- not later,
+        # when the abandoned greenlet happens to be collected.
+        assert log == ["handler raises", "caller finally", "caught"]
+
+    def test_handler_exception_runs_caller_wind_after(self):
+        """A wind guard in the caller is unwound when the handler raises."""
+        e: Effect[[], int] = effect("e")
+        h: Handler[int] = create_handler(e)
+
+        log: list[str] = []
+
+        @h.on(e)
+        def _handle(k: Resume[int, int]) -> int:
+            raise ValueError("handler error")
+
+        def caller() -> int:
+            with wind(lambda: log.append("before"), lambda: log.append("after")):
+                return e()
+
+        with pytest.raises(ValueError, match="handler error") as excinfo:
+            h(caller)
+
+        assert excinfo.value.__traceback__ is not None
+        assert log == ["before", "after"]
+
+    def test_unhandled_effect_in_continuation_unwinds_caller(self):
+        """A dispatch failure mid-continuation unwinds the caller too."""
+        e: Effect[[], int] = effect("e")
+        missing: Effect[[], int] = effect("missing")
+        h: Handler[int] = create_handler(e)
+
+        log: list[str] = []
+
+        @h.on(e)
+        def _handle(k: Resume[int, int]) -> int:
+            return k(1)
+
+        def caller() -> int:
+            with wind(lambda: log.append("before"), lambda: log.append("after")):
+                v = e()
+                missing()
+                return v
+
+        with pytest.raises(EffectNotHandledError) as excinfo:
+            h(caller)
+
+        assert excinfo.value.__traceback__ is not None
+        assert log == ["before", "after"]
+
+    def test_nested_handler_exception_unwinds_both_callers(self):
+        """Each suspended caller in the chain is unwound, innermost first."""
+        outer_e: Effect[[], int] = effect("outer_e")
+        inner_e: Effect[[], int] = effect("inner_e")
+
+        h_outer: Handler[int] = create_handler(outer_e)
+        h_inner: Handler[int] = create_handler(inner_e)
+
+        log: list[str] = []
+
+        @h_outer.on(outer_e)
+        def _handle_outer(k: Resume[int, int]) -> int:
+            raise ValueError("handler error")
+
+        @h_inner.on(inner_e)
+        def _handle_inner(k: Resume[int, int]) -> int:
+            return k(outer_e())
+
+        def inner_caller() -> int:
+            try:
+                return inner_e()
+            finally:
+                log.append("inner finally")
+
+        def outer_caller() -> int:
+            try:
+                return h_inner(inner_caller)
+            finally:
+                log.append("outer finally")
+
+        with pytest.raises(ValueError, match="handler error") as excinfo:
+            h_outer(outer_caller)
+
+        assert excinfo.value.__traceback__ is not None
+        assert log == ["inner finally", "outer finally"]
+
+    def test_caller_cleanup_exception_propagates(self):
+        """A cleanup failure during the abort is not swallowed."""
+        e: Effect[[], int] = effect("e")
+        h: Handler[int] = create_handler(e)
+
+        @h.on(e)
+        def _handle(k: Resume[int, int]) -> int:
+            raise ValueError("handler error")
+
+        def caller() -> int:
+            try:
+                return e()
+            finally:
+                raise RuntimeError("cleanup error")
+
+        # Standard finally semantics: the cleanup failure replaces the
+        # in-flight exception rather than being discarded.
+        with pytest.raises(RuntimeError, match="cleanup error"):
+            h(caller)
+
+    def test_handler_exception_after_resume_does_not_double_abort(self):
+        """A caller that already ran to completion is not aborted again."""
+        e: Effect[[], int] = effect("e")
+        h: Handler[int] = create_handler(e)
+
+        log: list[str] = []
+
+        @h.on(e)
+        def _handle(k: Resume[int, int]) -> int:
+            k(42)
+            raise ValueError("post-resume")
+
+        def caller() -> int:
+            try:
+                return e()
+            finally:
+                log.append("caller finally")
+
+        with pytest.raises(ValueError, match="post-resume"):
+            h(caller)
+
+        assert log == ["caller finally"]
+
+
+class TestAsyncAbortOnHandlerException:
+    @pytest.mark.asyncio
+    async def test_async_handler_exception_runs_caller_finally(self):
+        """The async handler path owes the caller the same abort."""
+        e: Effect[[], int] = effect("e")
+        h: AsyncHandler[int] = create_async_handler(e)
+
+        log: list[str] = []
+
+        @h.on(e)
+        async def _handle(k: ResumeAsync[int, int]) -> int:
+            log.append("handler raises")
+            raise ValueError("handler error")
+
+        def caller() -> int:
+            try:
+                return e()
+            finally:
+                log.append("caller finally")
+
+        with pytest.raises(ValueError, match="handler error") as excinfo:
+            await h(caller)
+        log.append("caught")
+
+        assert excinfo.value.__traceback__ is not None
+        assert log == ["handler raises", "caller finally", "caught"]
+
+    @pytest.mark.asyncio
+    async def test_async_sync_handler_fn_exception_runs_caller_finally(self):
+        """A sync handler fn under an async handler takes the same path."""
+        e: Effect[[], int] = effect("e")
+        h: AsyncHandler[int] = create_async_handler(e)
+
+        log: list[str] = []
+
+        @h.on(e)
+        def _handle(k: ResumeAsync[int, int]) -> int:
+            raise ValueError("handler error")
+
+        def caller() -> int:
+            with wind(lambda: log.append("before"), lambda: log.append("after")):
+                return e()
+
+        with pytest.raises(ValueError, match="handler error") as excinfo:
+            await h(caller)
+
+        assert excinfo.value.__traceback__ is not None
+        assert log == ["before", "after"]
 
 
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
Closes #37.

## Root cause

When a handler returns without resuming, `_drive` aborts the caller so its
`finally` blocks and `wind` guards run (`handlers.py:285-289`). When a handler
**raises**, the caller is suspended in exactly the same state — but
`handlers.py:283` was not protected by `try`/`finally`, so that cleanup was
skipped entirely. The async path had the same shape at
`handlers.py:457-470` → `472-476`, and dispatch failure
(`EffectNotHandledError` from `handlers.py:243`) went through the same hole.

The caller greenlet is then abandoned mid-effect:

- while the traceback is held, the cleanup **never runs**;
- otherwise it runs when the greenlet is collected and `GreenletExit` is
  injected — after the enclosing `except` block has already completed, i.e.
  outside its dynamic extent at a non-deterministic point.

## Changes

**Make the abort an invariant.** The whole post-effect region of `_drive` /
`_drive_async` is wrapped in `try`/`finally`, so when these functions return,
the caller is never still suspended — whether the handler returned without
resuming, raised, or dispatch failed. The normal-return branch folds into the
same `finally` instead of being a separate condition.
`_drive_effect` / `_drive_effect_async` are extracted so the `try` block stays
a single statement.

**Redirect `caller_gl.parent` in `_abort_caller`,** the way
`_Resume.__call__` already does (`handlers.py:115-122`). A dying greenlet hands
its exception to its *parent*, not to whoever switched into it. On the async
path the abort is driven from the handler fn's greenlet, which is not the
caller's parent at that moment, so `EffectAborted` escaped `_abort_caller`
instead of being absorbed — this surfaced as a failure in the existing
`test_shallow.py::TestShallowAsyncErrors::test_second_occurrence_unhandled_raises`
once the abort actually started running on that path.

The same redirection routes a cleanup failure back to the aborting greenlet,
where standard `finally` semantics let it replace the in-flight exception
rather than be silently discarded.

## Note on the tests

`pytest.raises` alone is not enough here. Without a live reference the
exception is dropped at the end of the `with` block, the abandoned greenlet is
collected immediately, and `GreenletExit` runs the cleanup anyway — so the
tests pass for the wrong reason. Six of the eight first drafts passed on `dev`
for exactly that reason. Each test now holds the traceback, which keeps the
suspended caller alive and makes the assertion observe the abort itself.

Covered: sync and async handlers, a sync handler fn under an async handler
(`_run_handler_fn_in_greenlet`), dispatch failure mid-continuation on both
paths, nested handlers unwinding innermost-first, and a cleanup that itself
raises. Plus a regression guard that a caller which already ran to completion
is not aborted twice.

## Verification

- `uv run pytest tests/` — 434 passed (425 existing + 9 new).
- `uv run pyright tests/ src/` — 0 errors, matching the baseline on `dev`.
- 8 of the 9 new tests fail at the test-only commit.
- Merged together with the #36 branch: no conflict, 451 passed.

## Out of scope

#38 — `after` is truncated when it performs an effect *during* an abort.
`_abort_caller` replies `ABORT` to every effect the unwinding caller performs,
so cleanup logic that performs effects is cut short. `before`/`after` counts
stay 1:1, and deciding whether effects are legal during unwinding is a
specification question rather than a bug fix.

## Commits

- `179ffde` test: add failing tests for caller unwinding on handler exception #37
- `a5532ea` fix: abort the caller when the handler does not return normally #37
