### PR TITLE
fix: resume past CALL_FUNCTION_EX and CALL_KW on Python 3.13+

### DIFF
--- a/src/aleff/_multishot/v1/_aleff.c
+++ b/src/aleff/_multishot/v1/_aleff.c
@@ -665,45 +665,59 @@ inject_resume_value(_aleff_frame_t *frame, PyObject *value)
          * 3.12 (prev_instr): points to the LAST executed instruction.
          *   Eval loop resumes at prev_instr + 1, so advance by SIZE - 1.
          * 3.13+ (instr_ptr): points to the NEXT instruction to execute.
-         *   Eval loop resumes at instr_ptr directly, so advance by SIZE. */
+         *   Eval loop resumes at instr_ptr directly, so advance by SIZE.
+         *
+         * The width is hardcoded rather than read from frame->return_offset,
+         * which is only meaningful while a call is in progress and is never
+         * cleared afterwards.  From 3.14 the eval loop saves a stack pointer
+         * even around escaping C calls, so stacktop >= 0 no longer implies
+         * this frame dispatched inline, and return_offset may still hold the
+         * width of some earlier call in the same frame. */
 #if PY_VERSION_HEX >= 0x030d0000
         ALEFF_PREV_INSTR(frame) += CALL_TOTAL_SIZE;
 #else
         ALEFF_PREV_INSTR(frame) += CALL_TOTAL_SIZE - 1;
 #endif
-    } else {
-        /* Non-CALL opcode.
-         * If stacktop >= 0, the eval loop saved a valid stack pointer.
-         * If stacktop == -1, this is an active frame; reset to base. */
+    }
+#if PY_VERSION_HEX >= 0x030d0000
+    else if (base_opcode == CALL_FUNCTION_EX || base_opcode == CALL_KW) {
+        /* Also calls, just not spelled CALL: f(*args) / f(**kwargs) compile to
+         * CALL_FUNCTION_EX, and a keyword call compiles to CALL_KW.  A frame
+         * suspended here must resume past the opcode, or it re-executes the
+         * call with nothing but the injected value on the stack.
+         *
+         * 3.12 needs no branch of its own: prev_instr means "last executed"
+         * and the eval loop resumes at prev_instr + 1, which is exactly past a
+         * one-codeunit CALL_FUNCTION_EX.  From 3.13 instr_ptr means "about to
+         * execute" and the resume point is instr_ptr + return_offset.
+         *
+         * return_offset is the width CPython itself recorded for this
+         * dispatch, so it absorbs per-version cache sizes -- CALL_KW has no
+         * cache entries on 3.13 and three on 3.14.  Reading it is sound here
+         * precisely because the opcode identifies the frame as mid-call, so
+         * the value belongs to the call being resumed.
+         *
+         * stacktop < 0 means the call escaped into C instead.  The C frame is
+         * then missing from the captured chain entirely, which is a separate
+         * unsupported case; treat it as any other escaping call. */
         if (stacktop < 0) {
             stacktop = value_stack_base;
         }
-#if PY_VERSION_HEX >= 0x030d0000
         else {
-            /* A saved stack pointer on a non-CALL opcode means the frame was
-             * dispatched inline, exactly as CALL is: the opcode is a call, just
-             * not CALL itself -- CALL_FUNCTION_EX (f(*args) / f(**kwargs)) or
-             * CALL_KW (f(a=1)).  The frame must resume past it; leaving the
-             * instruction pointer alone re-executes the call with only the
-             * injected value on the stack.
-             *
-             * 3.12 gets away with it: prev_instr means "last executed", the
-             * eval loop resumes at prev_instr + 1, and CALL_FUNCTION_EX is one
-             * codeunit wide, so the implicit +1 happens to be right.  From 3.13
-             * instr_ptr means "about to execute" and the resume point is
-             * instr_ptr + return_offset.
-             *
-             * return_offset is CPython's own record of where to resume once the
-             * call returns, so it absorbs per-version cache sizes -- CALL_KW
-             * has no cache entries on 3.13 and three on 3.14.
-             *
-             * The stacktop < 0 side is left alone.  Those are frames suspended
-             * beneath an escaping C call (operator, attribute and subscript
-             * dispatch into Python), which is a separate unsupported case: the
-             * C frame is not in the chain at all. */
             ALEFF_PREV_INSTR(frame) += frame->return_offset;
         }
+    }
 #endif
+    else {
+        /* Not a call at all: the frame is suspended beneath an escaping C
+         * call that dispatched back into Python -- operator, attribute or
+         * subscript lookup.  That C frame is absent from the captured chain,
+         * so the continuation cannot be replayed faithfully; this is a known
+         * unsupported shape.  Reset an active frame's stack to base and leave
+         * the instruction pointer alone. */
+        if (stacktop < 0) {
+            stacktop = value_stack_base;
+        }
     }
 
     #undef CALL_TOTAL_SIZE

--- a/src/aleff/_multishot/v1/_aleff.c
+++ b/src/aleff/_multishot/v1/_aleff.c
@@ -678,6 +678,32 @@ inject_resume_value(_aleff_frame_t *frame, PyObject *value)
         if (stacktop < 0) {
             stacktop = value_stack_base;
         }
+#if PY_VERSION_HEX >= 0x030d0000
+        else {
+            /* A saved stack pointer on a non-CALL opcode means the frame was
+             * dispatched inline, exactly as CALL is: the opcode is a call, just
+             * not CALL itself -- CALL_FUNCTION_EX (f(*args) / f(**kwargs)) or
+             * CALL_KW (f(a=1)).  The frame must resume past it; leaving the
+             * instruction pointer alone re-executes the call with only the
+             * injected value on the stack.
+             *
+             * 3.12 gets away with it: prev_instr means "last executed", the
+             * eval loop resumes at prev_instr + 1, and CALL_FUNCTION_EX is one
+             * codeunit wide, so the implicit +1 happens to be right.  From 3.13
+             * instr_ptr means "about to execute" and the resume point is
+             * instr_ptr + return_offset.
+             *
+             * return_offset is CPython's own record of where to resume once the
+             * call returns, so it absorbs per-version cache sizes -- CALL_KW
+             * has no cache entries on 3.13 and three on 3.14.
+             *
+             * The stacktop < 0 side is left alone.  Those are frames suspended
+             * beneath an escaping C call (operator, attribute and subscript
+             * dispatch into Python), which is a separate unsupported case: the
+             * C frame is not in the chain at all. */
+            ALEFF_PREV_INSTR(frame) += frame->return_offset;
+        }
+#endif
     }
 
     #undef CALL_TOTAL_SIZE

--- a/tests/test_multishot.py
+++ b/tests/test_multishot.py
@@ -5,6 +5,7 @@ each time resuming from the same suspension point with independent state.
 """
 
 import asyncio
+from typing import Any
 
 import pytest
 import pytest_asyncio  # pyright: ignore[reportUnusedImport]
@@ -305,6 +306,131 @@ class TestMultiShotDeepCalls:
         # This generates all 2-bit binary numbers
         result = h(lambda: binary_string(2))
         assert result == [0, 1, 2, 3]
+
+
+# ---------------------------------------------------------------------------
+# Multi-shot: call shapes in the captured chain
+#
+# A frame suspended mid-call has to be resumed just past the call opcode.
+# `f(a)` compiles to CALL, but `f(*args)` and `f(**kwargs)` compile to
+# CALL_FUNCTION_EX, and on 3.13+ `f(a=1)` compiles to CALL_KW -- each of which
+# has its own width and its own resume offset.
+# ---------------------------------------------------------------------------
+
+
+class TestMultiShotCallShapes:
+    def test_multishot_through_star_args_call(self):
+        """The continuation crosses a f(*args) call."""
+        choose: Effect[[], int] = effect("choose")
+        h: Handler[list[int]] = create_handler(choose)
+
+        @h.on(choose)
+        def _choose(k: Resume[int, list[int]]) -> list[int]:
+            return [*k(1), *k(2)]
+
+        def f(a: int) -> list[int]:
+            return [choose() + a]
+
+        args = (10,)
+        assert h(lambda: f(*args)) == [11, 12]
+
+    def test_multishot_through_star_args_call_three_shots(self):
+        """The same frame is re-entered once per shot."""
+        choose: Effect[[], int] = effect("choose")
+        h: Handler[list[int]] = create_handler(choose)
+
+        @h.on(choose)
+        def _choose(k: Resume[int, list[int]]) -> list[int]:
+            return [*k(1), *k(2), *k(3)]
+
+        def f(a: int) -> list[int]:
+            return [choose() + a]
+
+        args = (10,)
+        assert h(lambda: f(*args)) == [11, 12, 13]
+
+    def test_multishot_through_double_star_kwargs_call(self):
+        """The continuation crosses a f(**kwargs) call."""
+        choose: Effect[[], int] = effect("choose")
+        h: Handler[list[int]] = create_handler(choose)
+
+        @h.on(choose)
+        def _choose(k: Resume[int, list[int]]) -> list[int]:
+            return [*k(1), *k(2)]
+
+        def f(a: int) -> list[int]:
+            return [choose() + a]
+
+        kwargs = {"a": 10}
+        assert h(lambda: f(**kwargs)) == [11, 12]
+
+    def test_multishot_through_keyword_call(self):
+        """The continuation crosses a keyword call (CALL_KW on 3.13+)."""
+        choose: Effect[[], int] = effect("choose")
+        h: Handler[list[int]] = create_handler(choose)
+
+        @h.on(choose)
+        def _choose(k: Resume[int, list[int]]) -> list[int]:
+            return [*k(1), *k(2)]
+
+        def f(a: int) -> list[int]:
+            return [choose() + a]
+
+        assert h(lambda: f(a=10)) == [11, 12]
+
+    def test_multishot_through_mixed_star_and_keyword_call(self):
+        """The continuation crosses a f(*args, b=...) call."""
+        choose: Effect[[], int] = effect("choose")
+        h: Handler[list[int]] = create_handler(choose)
+
+        @h.on(choose)
+        def _choose(k: Resume[int, list[int]]) -> list[int]:
+            return [*k(1), *k(2)]
+
+        def g(a: int, b: int) -> list[int]:
+            return [choose() + a + b]
+
+        args = (10,)
+        assert h(lambda: g(*args, b=100)) == [111, 112]
+
+    def test_multishot_through_nested_handlers(self):
+        """The inner continuation contains the library's own *args dispatch.
+
+        `_drive` calls the handler fn as `d.fn(resume, *d.args, **d.kwargs)`, so
+        a nested handler puts a CALL_FUNCTION_EX frame in the captured chain
+        without any starred call in user code.
+        """
+        inner_e: Effect[[], int] = effect("inner")
+        outer_e: Effect[[int], int] = effect("outer")
+
+        h_outer: Handler[Any] = create_handler(outer_e)
+        h_inner: Handler[Any] = create_handler(inner_e)
+
+        @h_outer.on(outer_e)
+        def _handle_outer(k: Resume[int, Any], v: int) -> list[Any]:
+            return [k(v), k(v + 100)]
+
+        @h_inner.on(inner_e)
+        def _handle_inner(k: Resume[int, Any]) -> Any:
+            return k(outer_e(7))
+
+        assert h_outer(lambda: h_inner(lambda: inner_e())) == [7, 107]
+
+    @pytest.mark.asyncio
+    async def test_async_multishot_through_star_args_call(self):
+        """The async re-entry path resumes the same call shapes."""
+        choose: Effect[[], int] = effect("choose")
+        h: AsyncHandler[list[int]] = create_async_handler(choose)
+
+        @h.on(choose)
+        async def _choose(k: ResumeAsync[int, list[int]]) -> list[int]:
+            return [*await k(1), *await k(2)]
+
+        def f(a: int) -> list[int]:
+            return [choose() + a]
+
+        args = (10,)
+        assert await h(lambda: f(*args)) == [11, 12]
 
 
 # ---------------------------------------------------------------------------

--- a/tests/test_multishot.py
+++ b/tests/test_multishot.py
@@ -310,15 +310,18 @@ class TestMultiShotDeepCalls:
 
 # ---------------------------------------------------------------------------
 # Multi-shot: call shapes in the captured chain
-#
-# A frame suspended mid-call has to be resumed just past the call opcode.
-# `f(a)` compiles to CALL, but `f(*args)` and `f(**kwargs)` compile to
-# CALL_FUNCTION_EX, and on 3.13+ `f(a=1)` compiles to CALL_KW -- each of which
-# has its own width and its own resume offset.
 # ---------------------------------------------------------------------------
 
 
 class TestMultiShotCallShapes:
+    """Multi-shot across calls that do not compile to a plain CALL.
+
+    A frame suspended mid-call is resumed just past the call opcode, and not
+    every call spells that opcode the same way: ``f(*args)`` and ``f(**kwargs)``
+    compile to CALL_FUNCTION_EX, and on 3.13+ a keyword call compiles to
+    CALL_KW.
+    """
+
     def test_multishot_through_star_args_call(self):
         """The continuation crosses a f(*args) call."""
         choose: Effect[[], int] = effect("choose")


### PR DESCRIPTION
Closes #43.

## Root cause

`inject_resume_value` (`src/aleff/_multishot/v1/_aleff.c:629-690`) branched on
whether the suspended opcode is `CALL`, and only advanced the instruction
pointer in that branch. `CALL_FUNCTION_EX` (`f(*args)` / `f(**kwargs)`) and
`CALL_KW` (`f(a=1)`) are call opcodes but are not `CALL`, so they fell through
to the `else` and the pointer was left alone.

The frame then resumed **at the call opcode itself** and re-executed it, with
only the injected resume value on the value stack instead of
`[callable, args, kwargs]`. `func == NULL` reached `check_args_iterable`:

```
#0 PyObject_GetOptionalAttr (v=0x0, name='__qualname__')
#1 _PyObject_FunctionStr (x=0x0)
#2 check_args_iterable (func=0x0) at Python/ceval.c:2976
#4 _aleff_restore_continuation at _aleff.c:860
```

3.12 was unaffected by coincidence. `prev_instr` means "last executed" and the
eval loop resumes at `prev_instr + 1`; `CALL_FUNCTION_EX` is one codeunit wide,
so the implicit `+1` lands exactly past it. From 3.13 `instr_ptr` means "about
to execute" and the resume point is `instr_ptr + return_offset`
(`pycore_frame.h:70-72`), so nothing advanced at all.

Nested handlers hit this with no starred call in user code: `_drive` invokes the
handler fn as `d.fn(resume, *d.args, **d.kwargs)` (`handlers.py:283`), which is
itself a `CALL_FUNCTION_EX`, so an inner continuation contains one of the
library's own frames.

## Relation to the earlier 3.13 port

An earlier investigation established that the 3.12 -> 3.13 move broke three
assumptions in `inject_resume_value`, and that the `_PyInterpreterFrame` layout
is byte-for-byte identical between the two — the breakage is purely semantic:

1. **Instruction pointer meaning.** `prev_instr` ("the instruction just
   dispatched", initialised to `_PyCode_CODE(code) - 1`) became `instr_ptr`
   ("the instruction currently executing or about to begin", initialised to
   `_PyCode_CODE(code)`). Reading or writing it with the old meaning resumes a
   restored frame one instruction off.
2. **Opcode numbering.** `CALL` moved from 171 to 53, so a hardcoded comparison
   silently stopped matching and the CALL cleanup path was never taken.
3. **CALL cache size.** Three CACHE entries in both versions, i.e. 4 codeunits,
   but hardcoding that was flagged as fragile.

All three are handled in the current code: the advance is version-conditional,
the opcode comes from `opcode_ids.h` through a locally built deopt table rather
than a literal, and `CALL_TOTAL_SIZE` stays 4.

What that work did not cover is opcodes **other than `CALL`** that are also
calls. `CALL_FUNCTION_EX` and `CALL_KW` never entered the `CALL` branch, so
point 1 was never applied to them — which is exactly this bug. The third point
is also why the new branch reads `return_offset` instead of adding a second
hardcoded width: `CALL_KW` carries no cache entries on 3.13 and three on 3.14.

## Change

Add a branch for `CALL_FUNCTION_EX` and `CALL_KW` that advances by
`frame->return_offset` — the width CPython itself recorded for the dispatch,
which absorbs per-version cache sizes (`CALL_KW` has no cache entries on 3.13
and three on 3.14).

**The branch is gated on the opcode, not on `stacktop`.** `return_offset` is
only meaningful while a call is in progress and is never cleared afterwards, so
it must not be consulted for a frame that is not suspended at a call. Measured:
a frame that makes an inline Python call and is later suspended at `BINARY_OP`
still reports `return_offset=4`, on both 3.13 and 3.14. Testing the opcode is
what makes the value trustworthy.

The first version of this PR gated on `stacktop >= 0` instead, on the premise
that a saved stack pointer means inline dispatch. Self-review caught that this
does not hold from 3.14, where the eval loop saves one even around escaping C
calls — see the third commit for the measurements and the regression it caused.

**The `CALL` branch keeps its hardcoded width** for the same reason: on 3.14 an
escaping `CALL` also has `stacktop >= 0` while `return_offset` is stale. That
rationale now lives in the code, next to the branch it constrains.

**Frames suspended at `BINARY_OP`, `LOAD_ATTR` or `BINARY_SUBSCR`** — an effect
performed inside a Python `__add__`, property getter or `__getitem__` — fall to
the final `else` untouched. Those are captured beneath an escaping C call that
is absent from the chain entirely: a separate, pre-existing unsupported shape
that this change neither fixes nor worsens.

## Verification

`./run_tests.sh` — **432 passed and 10/10 examples on all four versions**
(3.12.13, 3.13.12, 3.14.3, 3.14.3t). C extension rebuilt per version; 0 compiler
warnings under `-Wall -Wextra -Wpedantic`. `pyright tests/ src/` — 0 errors.

Minimal repro (single handler, no `wind`, no nesting):

| Python | before | after |
|---|---|---|
| 3.12.13 | `[11, 20]` | `[11, 20]` |
| 3.13.12 | exit 139 | `[11, 20]` |
| 3.14.3 | exit 139 | `[11, 20]` |
| 3.14.3t | exit 139 | `[11, 20]` |

Non-regression against `origin/dev`, six probes across all four versions —
**23 of 24 combinations identical**:

| probe | 3.12.13 | 3.13.12 | 3.14.3 | 3.14.3t |
|---|---|---|---|---|
| `A() + 10` | 139 | 139 | `[11, 30]` | `[11, 30]` |
| `A().p` | 139 | `AttributeError` | `AttributeError` | `AttributeError` |
| `A()[10]` | 139 | 139 | `TypeError` | `TypeError` |
| escaping `CALL` after an inline call | `[[1], 10]` | `[[1], 10]` | `[[1], 10]` | `[[1], 10]` |
| `BINARY_OP` after an inline call | 139 | 139 | `[11, 30]` | `[11, 30]` |
| `sorted(*args, key=…)` after an inline call | `[[[[1,2,3],20],10],30]` | 139 | ⚠️ | ⚠️ |

⚠️ **The one difference.** A `CALL_FUNCTION_EX` that escapes into C, in a frame
that previously made an inline call, changes on 3.14 and 3.14t from a raw
SIGSEGV to CPython's own
`Fatal Python error: _PyEval_EvalFrameDefault: Executing a cache.`

That shape captures beneath a C frame — unsupported, and it crashes either way.
3.14 offers no way to distinguish an escaping call from an inline one at the
frame level, which is exactly why the `CALL` branch cannot use `return_offset`
either, so it cannot be excluded here. A diagnosed fatal error seemed the better
of the two crashes; happy to revisit if you would rather keep the segfault.

## Tests

7 new tests in `tests/test_multishot.py::TestMultiShotCallShapes`: `f(*args)`,
`f(**kwargs)`, `f(a=1)`, `f(*args, b=...)`, a three-shot variant, nested
handlers, and the async re-entry path. They pass on 3.12 and segfault the
interpreter on 3.13 at the test-only commit, so they abort the run rather than
reporting a failure.

## Effect on #41

#41 is red because its nested-multi-shot test is the first in the suite to put a
`CALL_FUNCTION_EX` frame into a captured chain. The crash reproduces on `dev`
with the script in #43, so that test is correct and the library was not. Once
this lands on `dev`, #41 goes green after picking up `dev`.

## Commits

- `54cda84` test: add failing tests for starred and keyword call shapes #43
- `d9e8f70` fix: resume past CALL_FUNCTION_EX and CALL_KW on Python 3.13+ #43
- `59b8962` fix: gate the resume-offset advance on the call opcode #43
