### PR TITLE
fix: resolve the 27 existing ruff check violations and gate ruff check in CI #47

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -23,6 +23,9 @@ jobs:
       - name: Ruff format check
         run: uv run ruff format --check
 
+      - name: Ruff check
+        run: uv run ruff check
+
   test:
     name: "Test (Python ${{ matrix.python-version }}, ${{ matrix.os }})"
     runs-on: ${{ matrix.os }}

--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -1,4 +1,5 @@
 import os
+import re
 import sys
 
 sys.path.insert(0, os.path.abspath("../../src"))
@@ -51,8 +52,6 @@ intersphinx_mapping = {
 
 
 # -- Convert markdown code blocks in docstrings to reST
-import re
-
 _CODE_BLOCK_RE = re.compile(
     r"^(?P<indent>\s*)```(?P<lang>\w*)\s*\n(?P<code>.*?)^(?P=indent)```\s*$",
     re.MULTILINE | re.DOTALL,

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -69,6 +69,15 @@ where = ["src"]
 
 [tool.ruff]
 line-length = 120
+# Apply the exclusions below even when a file is named on the command line, so that
+# checking a single file from an editor gives the same answer as CI.
+force-exclude = true
+
+[tool.ruff.lint]
+# Archived one-shot implementations, kept as development history and unreachable from
+# the public API (`_oneshot/__init__.py` exposes only `v8_1`, which stays in scope).
+# Keep in sync with the `ignore` list in pyrightconfig.json.
+exclude = ["src/aleff/_oneshot/v[1-8]/**"]
 
 [tool.cibuildwheel]
 build = ["cp312-*", "cp313-*", "cp314-*", "cp314t-*"]

--- a/src/aleff/__init__.py
+++ b/src/aleff/__init__.py
@@ -4,7 +4,7 @@ from importlib.metadata import version
 __version__ = version("aleff")
 
 try:
-    from .multishot import *
+    from .multishot import *  # noqa: F403
 except ImportError:
     _warnings.warn(
         "aleff.multishot is not available in this environment.\nUse 'import aleff.oneshot' for one-shot handlers.",

--- a/src/aleff/_multishot/__init__.py
+++ b/src/aleff/_multishot/__init__.py
@@ -1,1 +1,1 @@
-from .v1 import *
+from .v1 import *  # noqa: F403

--- a/src/aleff/_multishot/v1/winds.py
+++ b/src/aleff/_multishot/v1/winds.py
@@ -9,6 +9,11 @@ import greenlet as gl
 from .intf import Ref, Wind
 
 
+def _noop() -> None:
+    """Default `before`/`after` for a wind that only marks a dynamic extent."""
+    return None
+
+
 @overload
 def wind[T, B: bool | None](
     before: Callable[[], AbstractContextManager[T, B]],
@@ -49,9 +54,9 @@ def wind[T, B: bool | None](  # pyright: ignore[reportInconsistentOverload]
 ) -> Wind[T, B]:
     if before is None:
         # T is None
-        before = cast(Callable[[], T], lambda: None)
+        before = cast(Callable[[], T], _noop)
     if after is None:
-        after = lambda: None
+        after = _noop
     return _Wind[T](before, after, auto_exit=auto_exit)  # pyright: ignore[reportReturnType]
 
 

--- a/src/aleff/_oneshot/__init__.py
+++ b/src/aleff/_oneshot/__init__.py
@@ -1,1 +1,1 @@
-from .v8_1 import *
+from .v8_1 import *  # noqa: F403

--- a/src/aleff/multishot/__init__.py
+++ b/src/aleff/multishot/__init__.py
@@ -1,1 +1,1 @@
-from aleff._multishot import *
+from aleff._multishot import *  # noqa: F403

--- a/src/aleff/oneshot/__init__.py
+++ b/src/aleff/oneshot/__init__.py
@@ -1,1 +1,1 @@
-from aleff._oneshot import *
+from aleff._oneshot import *  # noqa: F403

--- a/tests/test_async.py
+++ b/tests/test_async.py
@@ -120,6 +120,46 @@ class TestAsyncHandler:
         assert order == ["outer_handle", "inner_enter", "inner_handle", "inner_exit", "outer_resumed"]
 
     @pytest.mark.asyncio
+    async def test_nested_handlers_in_async_body(self):
+        """An inner async handler can run inside an async body, before an outer effect.
+
+        The `order` list is a contract: the inner handler completes before the outer
+        effect is performed, and the outer continuation resumes after that.
+
+        Deliberately not mirrored in the one-shot suite: performing an effect from an
+        `async def` body raises `EffectNotHandledError` there, with or without an inner
+        handler, so the one-shot failure is unrelated to nesting.
+        """
+        inner_eff: Effect[[], str] = effect("inner_in_body")
+        outer_eff: Effect[[], int] = effect("outer_in_body")
+        order: list[str] = []
+
+        h_inner: AsyncHandler[str] = create_async_handler(inner_eff)
+
+        @h_inner.on(inner_eff)
+        async def _inner(k: ResumeAsync[str, str]):
+            order.append("inner_handle")
+            return await k("I")
+
+        h_outer: AsyncHandler[str] = create_async_handler(outer_eff)
+
+        @h_outer.on(outer_eff)
+        async def _outer(k: ResumeAsync[int, str]):
+            order.append("outer_handle")
+            result = await k(99)
+            order.append("outer_resumed")
+            return result
+
+        async def body():
+            got = await h_inner(lambda: inner_eff())
+            order.append("inner_done")
+            n = outer_eff()
+            return f"{got}:{n}"
+
+        assert await h_outer(body) == "I:99"
+        assert order == ["inner_handle", "inner_done", "outer_handle", "outer_resumed"]
+
+    @pytest.mark.asyncio
     async def test_effect_with_arguments(self):
         add: Effect[[int, int], int] = effect("add")
         h: AsyncHandler[int] = create_async_handler(add)

--- a/tests/test_async.py
+++ b/tests/test_async.py
@@ -1,7 +1,6 @@
 import asyncio
 
 import pytest
-import pytest_asyncio  # pyright: ignore[reportUnusedImport]
 
 from aleff import (
     effect,
@@ -83,37 +82,42 @@ class TestAsyncHandler:
 
     @pytest.mark.asyncio
     async def test_nested_handlers(self):
+        """An inner async handler runs to completion inside the outer handler fn.
+
+        The `order` list is a contract, not an artefact of the current implementation:
+        nesting means the inner handler finishes before the outer continuation resumes.
+        """
         inner_eff: Effect[[], str] = effect("inner")
         outer_eff: Effect[[], int] = effect("outer")
+        order: list[str] = []
 
         async def run_inner():
             h: AsyncHandler[str] = create_async_handler(inner_eff)
 
             @h.on(inner_eff)
             async def _handle(k: ResumeAsync[str, str]):
+                order.append("inner_handle")
                 return await k("from_inner")
 
-            return await h(lambda: inner_eff())
+            order.append("inner_enter")
+            result = await h(lambda: inner_eff())
+            order.append("inner_exit")
+            return result
 
         async def run_outer():
             h: AsyncHandler[int] = create_async_handler(outer_eff)
 
             @h.on(outer_eff)
             async def _handle(k: ResumeAsync[int, int]):
-                return await k(99)
+                order.append("outer_handle")
+                result = await k(len(await run_inner()))
+                order.append("outer_resumed")
+                return result
 
-            def body():
-                run_inner_result = run_inner()  # pyright: ignore[reportUnusedVariable]
-                # run_inner returns a coroutine; it will be awaited by _drive_async
-                # But we need the inner handler to complete first.
-                # For nesting, inner must be sync or handled differently.
-                return outer_eff()
+            return await h(lambda: outer_eff())
 
-            return await h(body)
-
-        # Nested async handlers require the inner to complete before outer effect.
-        # Use a different pattern: inner as sync handler.
-        pass
+        assert await run_outer() == 10
+        assert order == ["outer_handle", "inner_enter", "inner_handle", "inner_exit", "outer_resumed"]
 
     @pytest.mark.asyncio
     async def test_effect_with_arguments(self):

--- a/tests/test_async_oneshot.py
+++ b/tests/test_async_oneshot.py
@@ -1,7 +1,6 @@
 import asyncio
 
 import pytest
-import pytest_asyncio  # pyright: ignore[reportUnusedImport]
 
 from aleff.oneshot import (
     effect,
@@ -83,37 +82,42 @@ class TestAsyncHandler:
 
     @pytest.mark.asyncio
     async def test_nested_handlers(self):
+        """An inner async handler runs to completion inside the outer handler fn.
+
+        The `order` list is a contract, not an artefact of the current implementation:
+        nesting means the inner handler finishes before the outer continuation resumes.
+        """
         inner_eff: Effect[[], str] = effect("inner")
         outer_eff: Effect[[], int] = effect("outer")
+        order: list[str] = []
 
         async def run_inner():
             h: AsyncHandler[str] = create_async_handler(inner_eff)
 
             @h.on(inner_eff)
             async def _handle(k: ResumeAsync[str, str]):
+                order.append("inner_handle")
                 return await k("from_inner")
 
-            return await h(lambda: inner_eff())
+            order.append("inner_enter")
+            result = await h(lambda: inner_eff())
+            order.append("inner_exit")
+            return result
 
         async def run_outer():
             h: AsyncHandler[int] = create_async_handler(outer_eff)
 
             @h.on(outer_eff)
             async def _handle(k: ResumeAsync[int, int]):
-                return await k(99)
+                order.append("outer_handle")
+                result = await k(len(await run_inner()))
+                order.append("outer_resumed")
+                return result
 
-            def body():
-                run_inner_result = run_inner()  # pyright: ignore[reportUnusedVariable]
-                # run_inner returns a coroutine; it will be awaited by _drive_async
-                # But we need the inner handler to complete first.
-                # For nesting, inner must be sync or handled differently.
-                return outer_eff()
+            return await h(lambda: outer_eff())
 
-            return await h(body)
-
-        # Nested async handlers require the inner to complete before outer effect.
-        # Use a different pattern: inner as sync handler.
-        pass
+        assert await run_outer() == 10
+        assert order == ["outer_handle", "inner_enter", "inner_handle", "inner_exit", "outer_resumed"]
 
     @pytest.mark.asyncio
     async def test_effect_with_arguments(self):

--- a/tests/test_dynamic_wind.py
+++ b/tests/test_dynamic_wind.py
@@ -11,7 +11,6 @@ from contextlib import contextmanager
 from typing import Any, Iterator
 
 import pytest
-import pytest_asyncio  # pyright: ignore[reportUnusedImport]
 
 from aleff import (
     effect,

--- a/tests/test_exception.py
+++ b/tests/test_exception.py
@@ -4,10 +4,7 @@ Defines and verifies the semantics for how exceptions interact with
 effect handlers in all supported scenarios.
 """
 
-import asyncio  # pyright: ignore[reportUnusedImport]
-
 import pytest
-import pytest_asyncio  # pyright: ignore[reportUnusedImport]
 
 from aleff import (
     effect,

--- a/tests/test_exception_oneshot.py
+++ b/tests/test_exception_oneshot.py
@@ -4,10 +4,7 @@ Defines and verifies the semantics for how exceptions interact with
 effect handlers in all supported scenarios.
 """
 
-import asyncio  # pyright: ignore[reportUnusedImport]
-
 import pytest
-import pytest_asyncio  # pyright: ignore[reportUnusedImport]
 
 from aleff.oneshot import (
     effect,

--- a/tests/test_handler_effects.py
+++ b/tests/test_handler_effects.py
@@ -5,10 +5,7 @@ enclosing (outer) handler on the stack, enabling handler-to-handler
 communication and layered architectures.
 """
 
-import asyncio  # pyright: ignore[reportUnusedImport]
-
 import pytest
-import pytest_asyncio  # pyright: ignore[reportUnusedImport]
 
 from aleff import (
     effect,

--- a/tests/test_handler_effects_oneshot.py
+++ b/tests/test_handler_effects_oneshot.py
@@ -3,10 +3,7 @@
 Oneshot-specific variant — imports from aleff.oneshot.
 """
 
-import asyncio  # pyright: ignore[reportUnusedImport]
-
 import pytest
-import pytest_asyncio  # pyright: ignore[reportUnusedImport]
 
 from aleff.oneshot import (
     effect,

--- a/tests/test_multishot.py
+++ b/tests/test_multishot.py
@@ -8,7 +8,6 @@ import asyncio
 from typing import Any
 
 import pytest
-import pytest_asyncio  # pyright: ignore[reportUnusedImport]
 
 from aleff import (
     effect,

--- a/tests/test_shallow.py
+++ b/tests/test_shallow.py
@@ -8,7 +8,6 @@ by this handler unless it is explicitly re-installed.
 import asyncio
 
 import pytest
-import pytest_asyncio  # pyright: ignore[reportUnusedImport]
 
 from aleff import (
     effect,

--- a/tests/test_shallow_oneshot.py
+++ b/tests/test_shallow_oneshot.py
@@ -8,7 +8,6 @@ by this handler unless it is explicitly re-installed.
 import asyncio
 
 import pytest
-import pytest_asyncio  # pyright: ignore[reportUnusedImport]
 
 from aleff.oneshot import (
     effect,


### PR DESCRIPTION
Closes #47.

## Root cause

`ruff check` has never been part of CI. The lint job runs only
`uv run pyright src/ tests/` and `uv run ruff format --check`, while `ruff` has
been a dev dependency since the first commit. With the tool installed but never
gated, 27 violations accumulated — 26 at `cf64be4`, the commit named in the
issue, plus one more added since.

Scope is the second factor. `pyrightconfig.json` ignores `_oneshot/v1`..`v8` and
`docs/`, but `[tool.ruff]` had no exclusions at all, so ruff was the only tool
looking at the archived implementations.

## Changes

**Gate it.** `uv run ruff check` is added to the lint job. Without this the
violations come back one commit at a time.

**Scope it.** `[tool.ruff.lint] exclude` skips `src/aleff/_oneshot/v[1-8]/**`,
matching what `pyrightconfig.json` already ignores. `lint.exclude` is used rather
than `[tool.ruff] extend-exclude` so that `ruff format` still covers those files.
`force-exclude = true` makes a single-file check agree with CI — without it,
`ruff check src/aleff/_oneshot/v6/effect.py` still reported F821 while
`ruff check` passed.

**Fix the rest.**

| Rule | Count | Change |
|---|---|---|
| F401 | 14 | Removed, along with the `# pyright: ignore[reportUnusedImport]` each carried. `pytest_asyncio` is registered through its `pytest11` entry point, so importing it is not what makes the async tests run. |
| F403 | 5 | `# noqa: F403`. These star imports are the intended re-export path. |
| F841 | 2 | Gone with the `test_nested_handlers` rewrite below. |
| E731 | 1 | The two `lambda: None` defaults in `wind()` become one shared `_noop`. |
| E402 | 1 | `import re` moved to the top of `docs/source/conf.py`. |
| F821 | 4 | Not fixed — see *Deliberately not changed*. |

## `test_nested_handlers`

The F841 site sat inside a test that asserted nothing: it defined `run_inner` and
`run_outer`, called neither, and ended in `pass`. Renaming the variable would
have kept a dead test alive, so the test now checks something instead.

Running the old `run_outer()` body verbatim returns `99` and emits
`RuntimeWarning: coroutine 'run_inner' was never awaited` on both
implementations. `run_inner()` only built a coroutine object and dropped it, so
the inner handler never ran and no nesting ever happened. The comments claimed
that nesting async handlers inside the body was unsupported; that is not what the
code showed. A `def` body cannot `await` — a Python constraint, not a library
one — and with an `async def` body multi-shot handles the nesting.

There are now two tests:

- `test_nested_handlers` (both suites) — the inner handler is awaited inside the
  outer handler fn. The `order` list is asserted as a contract: the inner handler
  finishes before the outer continuation resumes.
- `test_nested_handlers_in_async_body` (multi-shot only) — the position the old
  comments described. There is no one-shot counterpart because performing an
  effect from an `async def` body raises `EffectNotHandledError` there whether or
  not an inner handler is involved, which makes it a separate defect rather than
  a nesting limitation.

## Deliberately not changed

- **F821 ×4 in `_oneshot/v6/effect.py`.** `_AbortSignal` and `_ResumeSignal` are
  undefined, so v6's async handler raises `NameError`. v6 is unreachable
  (`_oneshot/__init__.py` exposes only `v8_1`) and referenced nowhere in the
  repository. The archived versions stay in the tree as development history, so
  they are excluded from linting rather than repaired or deleted.
- **`aleff.v1` in the public namespace.** Star imports do not propagate `__all__`,
  so `aleff.v1` and `aleff.multishot.v1` are exposed unintentionally. Replacing
  the star imports would remove them, which is a public API change and outside the
  scope of a lint fix.
- **`docs/`.** Kept in ruff's scope. `conf.py` is live code and the E402 fix is a
  proven no-op.
- **`return None` in `_noop`.** Explicit by intent.
- **`if: always()` on the CI lint steps.** A CI behaviour change beyond this issue.

## Verification

| Gate | Result |
|---|---|
| `uv run ruff check` | passed (27 → 0) |
| `uv run ruff check src/aleff/_oneshot/v6/effect.py` | passed on an explicit path, was 4 × F821 |
| `uv run ruff format --check` | 73 files already formatted |
| `uv run pyright src/ tests/` | 0 errors, 0 warnings |
| `./run_tests.sh` | 3.12.13 / 3.13.12 / 3.14.3: 459 passed, 3 skipped · 3.14.3t: 462 passed · examples 10/10 on all four |
| Docs build | HTML output byte-identical before and after the `conf.py` change |
| Exclusion scope | Checked with temporary files: `v8_1` is linted, `v1` and `v6` are not, in both discovery and explicit-path mode |

`ruff check --fix` is not a substitute here. It rewrites
`run_inner_result = run_inner()` into a bare call, which then trips pyright's
`reportUnusedCoroutine` and breaks the lint job the fix was meant to satisfy.

## Commits

- `c324909` test: assert nested async handler behavior #47
- `c8e0ced` test: cover nested async handlers inside an async body #47
- `ba001c9` fix: resolve ruff check violations #47
- `9604e1c` ci: gate ruff check and exclude the archived one-shot versions #47
