### PR TITLE
Fix asyncio task protocol handling in coroutine bridges

### DIFF
--- a/src/aleff/_multishot/v1/handlers.py
+++ b/src/aleff/_multishot/v1/handlers.py
@@ -1,4 +1,4 @@
-from asyncio import Lock, iscoroutine
+from asyncio import Lock, iscoroutine, sleep
 from contextvars import ContextVar, copy_context
 from dataclasses import dataclass
 from inspect import iscoroutinefunction
@@ -354,12 +354,58 @@ class _AwaitRequest[V]:
         self.awaitable = awaitable
 
 
+class _BareYieldRequest:
+    """Requests resumption on the next event-loop turn without an awaitable."""
+
+    __slots__ = ()
+
+
+_BARE_YIELD_REQUEST = _BareYieldRequest()
+type _CoroutineRequest[V] = _AwaitRequest[V] | _BareYieldRequest
+
+
 def _is_effect_context(v: Any) -> TypeGuard[EffectContext[..., Any]]:
     return isinstance(v, EffectContext)
 
 
-def _is_await_request(v: Any) -> TypeGuard[_AwaitRequest[Any]]:
-    return isinstance(v, _AwaitRequest)
+def _is_coroutine_request(v: Any) -> TypeGuard[_CoroutineRequest[Any]]:
+    return isinstance(v, (_AwaitRequest, _BareYieldRequest))
+
+
+def _run_coroutine_in_bridge[V](coro: Coroutine[Any, Any, V]) -> V:
+    """Relay coroutine await requests and exceptions across a greenlet boundary."""
+    pending_exception: BaseException | None = None
+    parent = gl.getcurrent().parent
+    assert parent is not None
+
+    try:
+        while True:
+            if pending_exception is None:
+                awaitable = coro.send(None)
+            else:
+                exc = pending_exception
+                pending_exception = None
+                awaitable = coro.throw(exc)
+
+            # Futures yielded via __await__() are marked as blocking for
+            # asyncio.Task. Clear the marker before awaiting them externally.
+            if hasattr(awaitable, "_asyncio_future_blocking"):
+                awaitable._asyncio_future_blocking = False
+
+            request = _BARE_YIELD_REQUEST if awaitable is None else _AwaitRequest(awaitable)
+            try:
+                parent.switch(request)
+            except BaseException as exc:
+                pending_exception = exc
+    except StopIteration as exc:
+        return cast(V, exc.value)
+
+
+async def _resolve_coroutine_request(request: _CoroutineRequest[Any]) -> None:
+    if isinstance(request, _BareYieldRequest):
+        await sleep(0)
+    else:
+        await request.awaitable
 
 
 async def _run_handler_fn_in_bridge(
@@ -372,21 +418,7 @@ async def _run_handler_fn_in_bridge(
     and relaying ``await`` requests back to the event loop."""
 
     def _bridge() -> Any:
-        coro = fn(*args, **kwargs)
-        val: Any = None
-        parent = gl.getcurrent().parent
-        assert parent is not None
-        try:
-            while True:
-                awaitable = coro.send(val)
-                # asyncio Futures set _asyncio_future_blocking when
-                # yielded via __await__().  Reset it so the awaitable
-                # can be properly re-awaited in the outer event loop.
-                if hasattr(awaitable, "_asyncio_future_blocking"):
-                    awaitable._asyncio_future_blocking = False
-                val = parent.switch(_AwaitRequest(awaitable))
-        except StopIteration as e:
-            return e.value
+        return _run_coroutine_in_bridge(fn(*args, **kwargs))
 
     handler_fn_gl = gl.greenlet(_bridge)
     handler_fn_gl.gr_context = copy_context()
@@ -395,13 +427,13 @@ async def _run_handler_fn_in_bridge(
     while not handler_fn_gl.dead:
         if _is_effect_context(v):
             v = await _drive_async(handler_fn_gl, v, exclude_token=exclude_token)
-        elif _is_await_request(v):
+        elif _is_coroutine_request(v):
             try:
-                result: Any = await v.awaitable
+                await _resolve_coroutine_request(v)
             except BaseException as e:
-                v = handler_fn_gl.throw(type(e), e, e.__traceback__)
+                v = handler_fn_gl.throw(e)
             else:
-                v = handler_fn_gl.switch(result)
+                v = handler_fn_gl.switch(None)
         else:
             break
 
@@ -431,21 +463,20 @@ async def _run_handler_fn_in_greenlet(
 
 async def _drive_async[V](
     caller_gl: Any,
-    value: V | _AwaitRequest[V] | EffectContext[..., Any],
+    value: V | _CoroutineRequest[V] | EffectContext[..., Any],
     exclude_token: object | None = None,
 ) -> V:
     debug("||> @main")
 
-    if isinstance(value, _AwaitRequest):
+    while _is_coroutine_request(value):
         # Bridge greenlet needs an awaitable resolved
         debug("||> bridge await")
-        req = cast(_AwaitRequest[V], value)
         try:
-            result = await req.awaitable
+            await _resolve_coroutine_request(value)
         except BaseException as e:
-            return await _drive_async(caller_gl, caller_gl.throw(e))
+            value = caller_gl.throw(e)
         else:
-            return await _drive_async(caller_gl, caller_gl.switch(result))
+            value = caller_gl.switch(None)
 
     if caller_gl.dead:
         # computation finished
@@ -648,16 +679,8 @@ class _AsyncHandler[V](
                 _orig = caller
 
                 def actual_caller() -> Any:
-                    coro = _orig()
-                    value: Any = None
-                    parent = gl.getcurrent().parent
-                    assert parent is not None
-                    try:
-                        while True:
-                            awaitable = coro.send(value)
-                            value = parent.switch(_AwaitRequest(awaitable))
-                    except StopIteration as e:
-                        return e.value
+                    coro = cast(Coroutine[Any, Any, V], _orig())
+                    return _run_coroutine_in_bridge(coro)
 
             caller_gl = gl.greenlet(actual_caller)
             caller_gl.gr_context = copy_context()

--- a/src/aleff/_oneshot/v8_1/handlers.py
+++ b/src/aleff/_oneshot/v8_1/handlers.py
@@ -1,4 +1,4 @@
-from asyncio import Lock, iscoroutine
+from asyncio import Lock, iscoroutine, sleep
 from contextvars import ContextVar, copy_context
 from dataclasses import dataclass
 from inspect import iscoroutinefunction
@@ -248,8 +248,58 @@ class _AwaitRequest:
         self.awaitable = awaitable
 
 
+class _BareYieldRequest:
+    """Requests resumption on the next event-loop turn without an awaitable."""
+
+    __slots__ = ()
+
+
+_BARE_YIELD_REQUEST = _BareYieldRequest()
+type _CoroutineRequest = _AwaitRequest | _BareYieldRequest
+
+
 def _is_effect_context(v: Any) -> TypeGuard[EffectContext[..., Any]]:
     return isinstance(v, EffectContext)
+
+
+def _is_coroutine_request(v: Any) -> TypeGuard[_CoroutineRequest]:
+    return isinstance(v, (_AwaitRequest, _BareYieldRequest))
+
+
+def _run_coroutine_in_bridge[V](coro: Coroutine[Any, Any, V]) -> V:
+    """Relay coroutine await requests and exceptions across a greenlet boundary."""
+    pending_exception: BaseException | None = None
+    parent = gl.getcurrent().parent
+    assert parent is not None
+
+    try:
+        while True:
+            if pending_exception is None:
+                awaitable = coro.send(None)
+            else:
+                exc = pending_exception
+                pending_exception = None
+                awaitable = coro.throw(exc)
+
+            # Futures yielded via __await__() are marked as blocking for
+            # asyncio.Task. Clear the marker before awaiting them externally.
+            if hasattr(awaitable, "_asyncio_future_blocking"):
+                awaitable._asyncio_future_blocking = False
+
+            request = _BARE_YIELD_REQUEST if awaitable is None else _AwaitRequest(awaitable)
+            try:
+                parent.switch(request)
+            except BaseException as exc:
+                pending_exception = exc
+    except StopIteration as exc:
+        return cast(V, exc.value)
+
+
+async def _resolve_coroutine_request(request: _CoroutineRequest) -> None:
+    if isinstance(request, _BareYieldRequest):
+        await sleep(0)
+    else:
+        await request.awaitable
 
 
 async def _run_handler_fn_in_bridge(
@@ -262,21 +312,7 @@ async def _run_handler_fn_in_bridge(
     and relaying ``await`` requests back to the event loop."""
 
     def _bridge() -> Any:
-        coro = fn(*args, **kwargs)
-        val: Any = None
-        parent = gl.getcurrent().parent
-        assert parent is not None
-        try:
-            while True:
-                awaitable = coro.send(val)
-                # asyncio Futures set _asyncio_future_blocking when
-                # yielded via __await__().  Reset it so the awaitable
-                # can be properly re-awaited in the outer event loop.
-                if hasattr(awaitable, "_asyncio_future_blocking"):
-                    awaitable._asyncio_future_blocking = False
-                val = parent.switch(_AwaitRequest(awaitable))
-        except StopIteration as e:
-            return e.value
+        return _run_coroutine_in_bridge(fn(*args, **kwargs))
 
     handler_fn_gl = gl.greenlet(_bridge)
     handler_fn_gl.gr_context = copy_context()
@@ -285,13 +321,13 @@ async def _run_handler_fn_in_bridge(
     while not handler_fn_gl.dead:
         if _is_effect_context(v):
             v = await _drive_async(handler_fn_gl, v, exclude_token=exclude_token)
-        elif isinstance(v, _AwaitRequest):
+        elif _is_coroutine_request(v):
             try:
-                result = await v.awaitable
+                await _resolve_coroutine_request(v)
             except BaseException as e:
-                v = handler_fn_gl.throw(type(e), e, e.__traceback__)
+                v = handler_fn_gl.throw(e)
             else:
-                v = handler_fn_gl.switch(result)
+                v = handler_fn_gl.switch(None)
         else:
             break
 

--- a/tests/test_async.py
+++ b/tests/test_async.py
@@ -1,4 +1,5 @@
 import asyncio
+from collections.abc import Generator
 
 import pytest
 
@@ -13,6 +14,22 @@ from aleff import (
     ResumeAsync,
     EffectNotHandledError,
 )
+
+
+class _TaskProtocolAwaitable:
+    """Awaitable that verifies Task-style resumption after its Future completes."""
+
+    def __init__(self, value: int) -> None:
+        loop = asyncio.get_running_loop()
+        self._future: asyncio.Future[int] = loop.create_future()
+        loop.call_soon(self._future.set_result, value)
+
+    def __await__(self) -> Generator[asyncio.Future[int], None, int]:
+        if not self._future.done():
+            self._future._asyncio_future_blocking = True
+            resume_value = yield self._future
+            assert resume_value is None
+        return self._future.result()
 
 
 # ---------------------------------------------------------------------------
@@ -67,6 +84,117 @@ class TestAsyncHandler:
 
         result = await h(lambda: e())
         assert result == "after_sleep"
+
+    @pytest.mark.asyncio
+    async def test_await_sleep_zero_in_handler(self):
+        """sleep(0) in a handler yields and then resumes the continuation."""
+        e: Effect[[], int] = effect("e")
+        h: AsyncHandler[int] = create_async_handler(e)
+
+        @h.on(e)
+        async def _handle(k: ResumeAsync[int, int]):
+            await asyncio.sleep(0)
+            return await k(1)
+
+        assert await h(lambda: e()) == 1
+
+    @pytest.mark.asyncio
+    async def test_await_sleep_zero_in_handler_yields_to_event_loop(self):
+        """sleep(0) preserves its contract to yield for one loop iteration."""
+        e: Effect[[], int] = effect("e")
+        h: AsyncHandler[int] = create_async_handler(e)
+        order: list[str] = []
+
+        @h.on(e)
+        async def _handle(k: ResumeAsync[int, int]):
+            order.append("before_sleep")
+            asyncio.get_running_loop().call_soon(order.append, "scheduled")
+            await asyncio.sleep(0)
+            order.append("after_sleep")
+            return await k(1)
+
+        assert await h(lambda: e()) == 1
+        assert order == ["before_sleep", "scheduled", "after_sleep"]
+
+    @pytest.mark.asyncio
+    async def test_await_negative_sleep_in_handler(self):
+        """A non-positive sleep delay follows asyncio's zero-delay path."""
+        e: Effect[[], int] = effect("e")
+        h: AsyncHandler[int] = create_async_handler(e)
+
+        @h.on(e)
+        async def _handle(k: ResumeAsync[int, int]):
+            await asyncio.sleep(-1)
+            return await k(1)
+
+        assert await h(lambda: e()) == 1
+
+    @pytest.mark.asyncio
+    async def test_awaited_future_exception_is_caught_in_handler(self):
+        """An exception from an awaited Future is thrown into the handler coroutine."""
+        e: Effect[[], int] = effect("e")
+        h: AsyncHandler[int] = create_async_handler(e)
+        future: asyncio.Future[None] = asyncio.get_running_loop().create_future()
+
+        @h.on(e)
+        async def _handle(k: ResumeAsync[int, int]):
+            try:
+                await future
+            except ValueError as exc:
+                assert str(exc) == "boom"
+                await asyncio.sleep(0)
+                return await k(1)
+
+            pytest.fail("the Future exception was not thrown into the handler")
+
+        asyncio.get_running_loop().call_soon(future.set_exception, ValueError("boom"))
+        assert await h(lambda: e()) == 1
+
+    @pytest.mark.asyncio
+    async def test_awaited_future_resumes_handler_with_none(self):
+        """A completed Future resumes the handler using Task's send(None) protocol."""
+        e: Effect[[], int] = effect("e")
+        h: AsyncHandler[int] = create_async_handler(e)
+
+        @h.on(e)
+        async def _handle(k: ResumeAsync[int, int]):
+            value = await _TaskProtocolAwaitable(7)
+            return await k(value)
+
+        assert await h(lambda: e()) == 7
+
+    @pytest.mark.asyncio
+    @pytest.mark.parametrize("delay", [0, 3600], ids=["bare-yield", "future"])
+    async def test_cancellation_during_handler_await_is_propagated_and_finalized(self, delay: float):
+        """Cancellation reaches the handler and permits asynchronous finalization."""
+        e: Effect[[], int] = effect("e")
+        h: AsyncHandler[int] = create_async_handler(e)
+        started = asyncio.Event()
+        cancelled = asyncio.Event()
+        finalized = asyncio.Event()
+
+        @h.on(e)
+        async def _handle(k: ResumeAsync[int, int]):
+            try:
+                started.set()
+                await asyncio.sleep(delay)
+                return await k(1)
+            except asyncio.CancelledError:
+                cancelled.set()
+                raise
+            finally:
+                await asyncio.sleep(0)
+                finalized.set()
+
+        task = asyncio.create_task(h(lambda: e()))
+        await started.wait()
+        task.cancel()
+
+        with pytest.raises(asyncio.CancelledError):
+            await task
+
+        assert cancelled.is_set()
+        assert finalized.is_set()
 
     @pytest.mark.asyncio
     async def test_abort_without_resume(self):
@@ -158,6 +286,139 @@ class TestAsyncHandler:
 
         assert await h_outer(body) == "I:99"
         assert order == ["inner_handle", "inner_done", "outer_handle", "outer_resumed"]
+
+    @pytest.mark.asyncio
+    @pytest.mark.parametrize("delay", [0, 0.001], ids=["bare-yield", "future"])
+    async def test_async_caller_can_await_before_performing_effect(self, delay: float):
+        """An async caller can await either Task yield path before an effect."""
+        e: Effect[[], int] = effect("e")
+        h: AsyncHandler[int] = create_async_handler(e)
+
+        @h.on(e)
+        async def _handle(k: ResumeAsync[int, int]):
+            return await k(1)
+
+        async def caller():
+            await asyncio.sleep(delay)
+            return e()
+
+        assert await h(caller) == 1
+
+    @pytest.mark.asyncio
+    async def test_awaited_future_exception_is_caught_in_async_caller(self):
+        """An exception from an awaited Future is thrown into the caller coroutine."""
+        e: Effect[[], int] = effect("e")
+        h: AsyncHandler[int] = create_async_handler(e)
+        future: asyncio.Future[None] = asyncio.get_running_loop().create_future()
+
+        @h.on(e)
+        async def _handle(k: ResumeAsync[int, int]):
+            return await k(1)
+
+        async def caller():
+            try:
+                await future
+            except ValueError as exc:
+                assert str(exc) == "boom"
+                await asyncio.sleep(0)
+                return e()
+
+            pytest.fail("the Future exception was not thrown into the caller")
+
+        asyncio.get_running_loop().call_soon(future.set_exception, ValueError("boom"))
+        assert await h(caller) == 1
+
+    @pytest.mark.asyncio
+    async def test_awaited_future_resumes_async_caller_with_none(self):
+        """A completed Future resumes the async caller using Task's send(None) protocol."""
+        e: Effect[[], int] = effect("e")
+        h: AsyncHandler[int] = create_async_handler(e)
+
+        @h.on(e)
+        async def _handle(k: ResumeAsync[int, int]):
+            return await k(1)
+
+        async def caller():
+            assert await _TaskProtocolAwaitable(7) == 7
+            return e()
+
+        assert await h(caller) == 1
+
+    @pytest.mark.asyncio
+    async def test_async_caller_handles_many_consecutive_awaits(self):
+        """Await requests are processed without growing the Python call stack."""
+        e: Effect[[], int] = effect("e")
+        h: AsyncHandler[int] = create_async_handler(e)
+
+        @h.on(e)
+        async def _handle(k: ResumeAsync[int, int]):
+            return await k(1)
+
+        async def caller():
+            for _ in range(1500):
+                await asyncio.sleep(0)
+            return e()
+
+        assert await h(caller) == 1
+
+    @pytest.mark.asyncio
+    async def test_async_caller_handles_many_consecutive_await_exceptions(self):
+        """Await exceptions are processed without growing the Python call stack."""
+        e: Effect[[], int] = effect("e")
+        h: AsyncHandler[int] = create_async_handler(e)
+
+        @h.on(e)
+        async def _handle(k: ResumeAsync[int, int]):
+            return await k(1)
+
+        async def caller():
+            loop = asyncio.get_running_loop()
+            for _ in range(1500):
+                future: asyncio.Future[None] = loop.create_future()
+                loop.call_soon(future.set_exception, ValueError("boom"))
+                try:
+                    await future
+                except ValueError:
+                    pass
+            return e()
+
+        assert await h(caller) == 1
+
+    @pytest.mark.asyncio
+    @pytest.mark.parametrize("delay", [0, 3600], ids=["bare-yield", "future"])
+    async def test_cancellation_during_async_caller_await_is_propagated_and_finalized(self, delay: float):
+        """Cancellation reaches an async caller and permits asynchronous finalization."""
+        e: Effect[[], int] = effect("e")
+        h: AsyncHandler[int] = create_async_handler(e)
+        started = asyncio.Event()
+        cancelled = asyncio.Event()
+        finalized = asyncio.Event()
+
+        @h.on(e)
+        async def _handle(k: ResumeAsync[int, int]):
+            return await k(1)
+
+        async def caller():
+            try:
+                started.set()
+                await asyncio.sleep(delay)
+                return e()
+            except asyncio.CancelledError:
+                cancelled.set()
+                raise
+            finally:
+                await asyncio.sleep(0)
+                finalized.set()
+
+        task = asyncio.create_task(h(caller))
+        await started.wait()
+        task.cancel()
+
+        with pytest.raises(asyncio.CancelledError):
+            await task
+
+        assert cancelled.is_set()
+        assert finalized.is_set()
 
     @pytest.mark.asyncio
     async def test_effect_with_arguments(self):

--- a/tests/test_async_oneshot.py
+++ b/tests/test_async_oneshot.py
@@ -1,4 +1,5 @@
 import asyncio
+from collections.abc import Generator
 
 import pytest
 
@@ -13,6 +14,22 @@ from aleff.oneshot import (
     ResumeAsync,
     EffectNotHandledError,
 )
+
+
+class _TaskProtocolAwaitable:
+    """Awaitable that verifies Task-style resumption after its Future completes."""
+
+    def __init__(self, value: int) -> None:
+        loop = asyncio.get_running_loop()
+        self._future: asyncio.Future[int] = loop.create_future()
+        loop.call_soon(self._future.set_result, value)
+
+    def __await__(self) -> Generator[asyncio.Future[int], None, int]:
+        if not self._future.done():
+            self._future._asyncio_future_blocking = True
+            resume_value = yield self._future
+            assert resume_value is None
+        return self._future.result()
 
 
 # ---------------------------------------------------------------------------
@@ -67,6 +84,117 @@ class TestAsyncHandler:
 
         result = await h(lambda: e())
         assert result == "after_sleep"
+
+    @pytest.mark.asyncio
+    async def test_await_sleep_zero_in_handler(self):
+        """sleep(0) in a handler yields and then resumes the continuation."""
+        e: Effect[[], int] = effect("e")
+        h: AsyncHandler[int] = create_async_handler(e)
+
+        @h.on(e)
+        async def _handle(k: ResumeAsync[int, int]):
+            await asyncio.sleep(0)
+            return await k(1)
+
+        assert await h(lambda: e()) == 1
+
+    @pytest.mark.asyncio
+    async def test_await_sleep_zero_in_handler_yields_to_event_loop(self):
+        """sleep(0) preserves its contract to yield for one loop iteration."""
+        e: Effect[[], int] = effect("e")
+        h: AsyncHandler[int] = create_async_handler(e)
+        order: list[str] = []
+
+        @h.on(e)
+        async def _handle(k: ResumeAsync[int, int]):
+            order.append("before_sleep")
+            asyncio.get_running_loop().call_soon(order.append, "scheduled")
+            await asyncio.sleep(0)
+            order.append("after_sleep")
+            return await k(1)
+
+        assert await h(lambda: e()) == 1
+        assert order == ["before_sleep", "scheduled", "after_sleep"]
+
+    @pytest.mark.asyncio
+    async def test_await_negative_sleep_in_handler(self):
+        """A non-positive sleep delay follows asyncio's zero-delay path."""
+        e: Effect[[], int] = effect("e")
+        h: AsyncHandler[int] = create_async_handler(e)
+
+        @h.on(e)
+        async def _handle(k: ResumeAsync[int, int]):
+            await asyncio.sleep(-1)
+            return await k(1)
+
+        assert await h(lambda: e()) == 1
+
+    @pytest.mark.asyncio
+    async def test_awaited_future_exception_is_caught_in_handler(self):
+        """An exception from an awaited Future is thrown into the handler coroutine."""
+        e: Effect[[], int] = effect("e")
+        h: AsyncHandler[int] = create_async_handler(e)
+        future: asyncio.Future[None] = asyncio.get_running_loop().create_future()
+
+        @h.on(e)
+        async def _handle(k: ResumeAsync[int, int]):
+            try:
+                await future
+            except ValueError as exc:
+                assert str(exc) == "boom"
+                await asyncio.sleep(0)
+                return await k(1)
+
+            pytest.fail("the Future exception was not thrown into the handler")
+
+        asyncio.get_running_loop().call_soon(future.set_exception, ValueError("boom"))
+        assert await h(lambda: e()) == 1
+
+    @pytest.mark.asyncio
+    async def test_awaited_future_resumes_handler_with_none(self):
+        """A completed Future resumes the handler using Task's send(None) protocol."""
+        e: Effect[[], int] = effect("e")
+        h: AsyncHandler[int] = create_async_handler(e)
+
+        @h.on(e)
+        async def _handle(k: ResumeAsync[int, int]):
+            value = await _TaskProtocolAwaitable(7)
+            return await k(value)
+
+        assert await h(lambda: e()) == 7
+
+    @pytest.mark.asyncio
+    @pytest.mark.parametrize("delay", [0, 3600], ids=["bare-yield", "future"])
+    async def test_cancellation_during_handler_await_is_propagated_and_finalized(self, delay: float):
+        """Cancellation reaches the handler and permits asynchronous finalization."""
+        e: Effect[[], int] = effect("e")
+        h: AsyncHandler[int] = create_async_handler(e)
+        started = asyncio.Event()
+        cancelled = asyncio.Event()
+        finalized = asyncio.Event()
+
+        @h.on(e)
+        async def _handle(k: ResumeAsync[int, int]):
+            try:
+                started.set()
+                await asyncio.sleep(delay)
+                return await k(1)
+            except asyncio.CancelledError:
+                cancelled.set()
+                raise
+            finally:
+                await asyncio.sleep(0)
+                finalized.set()
+
+        task = asyncio.create_task(h(lambda: e()))
+        await started.wait()
+        task.cancel()
+
+        with pytest.raises(asyncio.CancelledError):
+            await task
+
+        assert cancelled.is_set()
+        assert finalized.is_set()
 
     @pytest.mark.asyncio
     async def test_abort_without_resume(self):


### PR DESCRIPTION
## Summary

- handle bare coroutine yields such as `asyncio.sleep(0)` by resuming on the next event-loop turn
- relay successful await completion with `send(None)` and propagate exceptions and cancellation with `throw()`
- share the coroutine driver between multishot async handlers and async callers
- process consecutive multishot async caller awaits iteratively to avoid recursion limits
- represent bare yields separately from awaitable requests

## Related issues

Closes #39
Closes #50

## Commits

- `b8ae46f` fix: align coroutine bridges with asyncio task protocol

## Testing

- `uv run pytest tests/` — 481 passed, 3 skipped
- `uv run ruff check src tests`
- `uv run ruff format --check src tests`
- `uv run pyright src tests` — 0 errors
- `git diff --check`
