### PR TITLE
Fix async multi-shot resume for async callers

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ version = "0.3.2"
 description = "Algebraic effects for Python — deep and shallow, stateful, composable, multi-shot handlers"
 readme = "README.md"
 license = "Apache-2.0"
-requires-python = ">=3.12"
+requires-python = ">=3.12,<3.15"
 authors = [
     { name = "hnmr" },
 ]

--- a/src/aleff/_multishot/v1/_aleff.c
+++ b/src/aleff/_multishot/v1/_aleff.c
@@ -279,11 +279,11 @@ typedef struct {
     int8_t cr_frame_state;
 } _aleff_coro_prefix_t;
 
-#define ALEFF_SET_CORO_FRAME_STATE(coro, state) \
-    (((_aleff_coro_prefix_t *)(coro))->cr_frame_state = (state))
-#define ALEFF_CORO_EXC_STATE(coro) \
-    (&((_aleff_coro_prefix_t *)(coro))->cr_exc_state)
-#define ALEFF_CORO_FROM_FRAME(frame) \
+#define ALEFF_SET_GEN_FRAME_STATE(owner, state) \
+    (((_aleff_coro_prefix_t *)(owner))->cr_frame_state = (state))
+#define ALEFF_GEN_EXC_STATE(owner) \
+    (&((_aleff_coro_prefix_t *)(owner))->cr_exc_state)
+#define ALEFF_GEN_FROM_FRAME(frame) \
     ((_aleff_coro_prefix_t *)((char *)(frame) - sizeof(_aleff_coro_prefix_t)))
 
 #else
@@ -325,11 +325,11 @@ _aleff_frame_set_stacktop(_aleff_frame_t *frame, int top)
 #define FRAME_OWNED_BY_FRAME_OBJECT 2
 #define FRAME_OWNED_BY_CSTACK 3
 
-#define ALEFF_SET_CORO_FRAME_STATE(coro, state) \
-    (((PyCoroObject *)(coro))->cr_frame_state = (state))
-#define ALEFF_CORO_EXC_STATE(coro) \
-    (&((PyCoroObject *)(coro))->cr_exc_state)
-#define ALEFF_CORO_FROM_FRAME(frame) \
+#define ALEFF_SET_GEN_FRAME_STATE(owner, state) \
+    (((PyCoroObject *)(owner))->cr_frame_state = (state))
+#define ALEFF_GEN_EXC_STATE(owner) \
+    (&((PyCoroObject *)(owner))->cr_exc_state)
+#define ALEFF_GEN_FROM_FRAME(frame) \
     ((PyCoroObject *)((char *)(frame) - offsetof(PyCoroObject, cr_iframe)))
 
 #endif /* PY_VERSION_HEX >= 0x030e0000 */
@@ -386,15 +386,20 @@ _aleff_is_exception_instance(PyObject *obj)
 static PyObject *
 _aleff_frame_handled_exception(_aleff_frame_t *frame, PyObject *fallback)
 {
-    PyCodeObject *code = _aleff_frame_get_code(frame);
-    if ((code->co_flags & CO_COROUTINE) && frame->owner == FRAME_OWNED_BY_GENERATOR) {
-        PyObject *coro = (PyObject *)ALEFF_CORO_FROM_FRAME(frame);
-        PyObject *exc = _aleff_effective_handled_exception(ALEFF_CORO_EXC_STATE(coro));
-        if (exc != nullptr) {
-            return exc;
-        }
+    if (frame->owner == FRAME_OWNED_BY_GENERATOR) {
+        PyObject *owner = (PyObject *)ALEFF_GEN_FROM_FRAME(frame);
+        return _aleff_effective_handled_exception(ALEFF_GEN_EXC_STATE(owner));
     }
     return _aleff_is_exception_instance(fallback) ? fallback : nullptr;
+}
+
+static PyObject *
+_aleff_frame_generator_owner(_aleff_frame_t *frame)
+{
+    if (frame->owner != FRAME_OWNED_BY_GENERATOR) {
+        return nullptr;
+    }
+    return (PyObject *)ALEFF_GEN_FROM_FRAME(frame);
 }
 
 static inline int
@@ -411,6 +416,7 @@ typedef struct {
     _aleff_frame_t *frame;  /* deep-copied frame */
     int num_slots;          /* number of localsplus slots */
     PyObject *handled_exception;  /* effective handled exception, or nullptr */
+    PyObject *original_owner;  /* generator/coroutine owner, or nullptr */
 } _aleff_frame_copy_t;
 
 typedef struct {
@@ -435,6 +441,7 @@ FrameSnapshot_dealloc(FrameSnapshotObject *self)
         Py_XDECREF(f->f_builtins);
         Py_XDECREF(f->f_locals);
         Py_XDECREF(fc->handled_exception);
+        Py_XDECREF(fc->original_owner);
         /* Don't decref frame_obj — we set it to nullptr in copies */
 
         for (int j = 0; j < fc->num_slots; j++) {
@@ -482,7 +489,7 @@ static PyTypeObject FrameSnapshotType = {
 static _aleff_frame_copy_t
 copy_single_frame(_aleff_frame_t *src)
 {
-    _aleff_frame_copy_t result = {nullptr, 0, nullptr};
+    _aleff_frame_copy_t result = {nullptr, 0, nullptr, nullptr};
 
     PyCodeObject *code = _aleff_frame_get_code(src);
     int num_slots = _aleff_frame_num_slots(code);
@@ -651,6 +658,9 @@ create_snapshot(PyFrameObject *boundary_frame, int max_depth)
             snapshot->frames[i].handled_exception = Py_XNewRef(
                 _aleff_frame_handled_exception(internal, fallback_exception)
             );
+            snapshot->frames[i].original_owner = Py_XNewRef(
+                _aleff_frame_generator_owner(internal)
+            );
 
             PyFrameObject *prev = PyFrame_GetBack(f);  /* new ref */
             Py_DECREF(f);
@@ -811,13 +821,45 @@ inject_resume_value(_aleff_frame_t *frame, PyObject *value)
     _aleff_frame_set_stacktop(frame, stacktop);
 }
 
+static PyObject *
+replacement_for(PyObject *obj, PyObject *replacements)
+{
+    if (obj == nullptr || replacements == nullptr || replacements == Py_None) {
+        return obj;
+    }
+
+    PyObject *original;
+    PyObject *replacement;
+    Py_ssize_t pos = 0;
+    while (PyDict_Next(replacements, &pos, &original, &replacement)) {
+        if (obj == original) {
+            return replacement;
+        }
+    }
+    return obj;
+}
+
+static void
+apply_frame_replacements(_aleff_frame_t *frame, int num_slots, PyObject *replacements)
+{
+    for (int i = 0; i < num_slots; i++) {
+        PyObject *obj = ALEFF_LOCALSPLUS_GET(frame, i);
+        ALEFF_LOCALSPLUS_SET(frame, i, replacement_for(obj, replacements));
+    }
+}
+
 /*
  * Copy a frame onto the thread data stack.
  * Returns a pointer to the frame on the data stack, or nullptr on error.
  * The caller must ensure there's enough space (or handle growth).
  */
 static _aleff_frame_t *
-push_frame_to_datastack(PyThreadState *tstate, _aleff_frame_t *src, int num_slots)
+push_frame_to_datastack(
+    PyThreadState *tstate,
+    _aleff_frame_t *src,
+    int num_slots,
+    PyObject *replacements
+)
 {
     size_t frame_size = sizeof(_aleff_frame_t)
                       + (num_slots - 1) * sizeof(PyObject *);
@@ -843,6 +885,8 @@ push_frame_to_datastack(PyThreadState *tstate, _aleff_frame_t *src, int num_slot
     }
 #endif
 
+    apply_frame_replacements(dst, num_slots, replacements);
+
     /* INCREF all references (the copy shares objects with the snapshot copy) */
     Py_XINCREF(ALEFF_GET_EXECUTABLE(dst));
     Py_XINCREF(ALEFF_GET_FUNCOBJ(dst));
@@ -861,18 +905,20 @@ push_frame_to_datastack(PyThreadState *tstate, _aleff_frame_t *src, int num_slot
     return dst;
 }
 
-/* Build a real coroutine object around a copied suspended coroutine frame.
+/* Build a real generator-family owner around a copied suspended frame.
  *
- * PyCoro_New() only accepts a PyFrameObject.  Create a correctly-sized frame
- * object, replace its freshly initialized interpreter frame with the snapshot
- * state, then let PyCoro_New() move that state into coroutine-owned storage.
+ * The public constructors accept a PyFrameObject.  Create a correctly-sized
+ * frame object, replace its freshly initialized interpreter frame with the
+ * snapshot state, then let the matching constructor move that state into
+ * generator-owned storage.
  */
 static PyObject *
-coroutine_from_frame_copy(
+generator_owner_from_frame_copy(
     PyThreadState *tstate,
     _aleff_frame_copy_t *src_copy,
     int resume_from_coroutine,
-    PyObject *handled_exception
+    PyObject *handled_exception,
+    PyObject *replacements
 )
 {
     _aleff_frame_t *src = src_copy->frame;
@@ -909,6 +955,8 @@ coroutine_from_frame_copy(
     }
 #endif
 
+    apply_frame_replacements(dst, src_copy->num_slots, replacements);
+
     /* Match normal interpreter-frame ownership: executable, function,
      * locals, and localsplus are strong; globals and builtins are borrowed. */
     Py_XINCREF(ALEFF_GET_EXECUTABLE(dst));
@@ -931,17 +979,26 @@ coroutine_from_frame_copy(
         prepare_resume_frame(dst);
     }
 
-    PyObject *coro = PyCoro_New(py_frame, code->co_name, code->co_qualname);
-    if (coro == nullptr) {
+    PyObject *owner;
+    if (code->co_flags & CO_ASYNC_GENERATOR) {
+        owner = PyAsyncGen_New(py_frame, code->co_name, code->co_qualname);
+    }
+    else if (code->co_flags & CO_COROUTINE) {
+        owner = PyCoro_New(py_frame, code->co_name, code->co_qualname);
+    }
+    else {
+        owner = PyGen_NewWithQualName(py_frame, code->co_name, code->co_qualname);
+    }
+    if (owner == nullptr) {
         return nullptr;
     }
 
 #if PY_VERSION_HEX >= 0x030d0000
-    ALEFF_SET_CORO_FRAME_STATE(coro, -2);  /* FRAME_SUSPENDED */
+    ALEFF_SET_GEN_FRAME_STATE(owner, -2);  /* FRAME_SUSPENDED */
 #else
-    ALEFF_SET_CORO_FRAME_STATE(coro, -1);  /* FRAME_SUSPENDED */
+    ALEFF_SET_GEN_FRAME_STATE(owner, -1);  /* FRAME_SUSPENDED */
 #endif
-    _PyErr_StackItem *exc_state = ALEFF_CORO_EXC_STATE(coro);
+    _PyErr_StackItem *exc_state = ALEFF_GEN_EXC_STATE(owner);
     Py_XSETREF(
         exc_state->exc_value,
         _aleff_is_exception_instance(handled_exception)
@@ -949,7 +1006,13 @@ coroutine_from_frame_copy(
             : nullptr
     );
     exc_state->previous_item = nullptr;
-    return coro;
+    if (src_copy->original_owner != nullptr && replacements != nullptr) {
+        if (PyDict_SetItem(replacements, src_copy->original_owner, owner) < 0) {
+            Py_DECREF(owner);
+            return nullptr;
+        }
+    }
+    return owner;
 }
 
 /* ========================================================================
@@ -1036,7 +1099,12 @@ _aleff_restore_continuation(_ALEFF_UNUSED PyObject *self, PyObject *args)
 
     for (int i = num - 1; i >= 0; i--) {
         _aleff_frame_copy_t *src = &snapshot->frames[i + skip];
-        _aleff_frame_t *f = push_frame_to_datastack(tstate, src->frame, src->num_slots);
+        _aleff_frame_t *f = push_frame_to_datastack(
+            tstate,
+            src->frame,
+            src->num_slots,
+            Py_None
+        );
         if (f == nullptr) {
             /* Restore data stack and bail */
             tstate->datastack_top = saved_datastack_top;
@@ -1130,7 +1198,7 @@ make_async_restore_stage(
 
 PyDoc_STRVAR(restore_async_continuation_doc,
 "restore_async_continuation(\n"
-"    snapshot, outcome, start=1, is_exception=False, from_coroutine=False\n"
+"    snapshot, outcome, start=1, is_exception=False, from_coroutine=False, replacements=None\n"
 ")\n"
 "--\n\n"
 "Advance a restored frame chain until its next coroutine frame or completion.\n"
@@ -1147,16 +1215,18 @@ _aleff_restore_async_continuation(_ALEFF_UNUSED PyObject *self, PyObject *args)
     int start = 1;
     int is_exception = 0;
     int from_coroutine = 0;
+    PyObject *replacements = Py_None;
 
     if (!PyArg_ParseTuple(
             args,
-            "O!O|ipp",
+            "O!O|ippO",
             &FrameSnapshotType,
             &snapshot,
             &outcome,
             &start,
             &is_exception,
-            &from_coroutine
+            &from_coroutine,
+            &replacements
         )) {
         return nullptr;
     }
@@ -1168,6 +1238,10 @@ _aleff_restore_async_continuation(_ALEFF_UNUSED PyObject *self, PyObject *args)
     }
     if (start < 0 || start > snapshot->num_frames) {
         PyErr_SetString(PyExc_ValueError, "invalid async continuation frame index");
+        return nullptr;
+    }
+    if (replacements != Py_None && !PyDict_Check(replacements)) {
+        PyErr_SetString(PyExc_TypeError, "replacements must be a dict or None");
         return nullptr;
     }
 
@@ -1187,20 +1261,44 @@ _aleff_restore_async_continuation(_ALEFF_UNUSED PyObject *self, PyObject *args)
         _aleff_frame_copy_t *src = &snapshot->frames[i];
         PyCodeObject *code = _aleff_frame_get_code(src->frame);
 
-        if (code->co_flags & CO_COROUTINE) {
-            PyObject *coro = coroutine_from_frame_copy(
+        if (code->co_flags & (CO_COROUTINE | CO_GENERATOR | CO_ASYNC_GENERATOR)) {
+            PyObject *owner = generator_owner_from_frame_copy(
                 tstate,
                 src,
                 from_coroutine && !pending_is_exception,
-                restored_exc_state.exc_value
+                restored_exc_state.exc_value,
+                replacements
             );
-            if (coro == nullptr) {
+            if (owner == nullptr) {
                 Py_DECREF(pending);
                 goto done;
             }
+
+            if (code->co_flags & CO_ASYNC_GENERATOR) {
+                PyObject *operation = PyObject_CallMethod(
+                    owner,
+                    pending_is_exception ? "athrow" : "asend",
+                    "O",
+                    pending
+                );
+                Py_DECREF(owner);
+                Py_DECREF(pending);
+                if (operation == nullptr) {
+                    goto done;
+                }
+                return_value = make_async_restore_stage(
+                    0,
+                    operation,
+                    i + 1,
+                    Py_NewRef(Py_None),
+                    0
+                );
+                goto done;
+            }
+
             return_value = make_async_restore_stage(
                 0,
-                coro,
+                owner,
                 i + 1,
                 pending,
                 pending_is_exception
@@ -1209,7 +1307,12 @@ _aleff_restore_async_continuation(_ALEFF_UNUSED PyObject *self, PyObject *args)
         }
 
         PyObject **saved_datastack_top = tstate->datastack_top;
-        _aleff_frame_t *frame = push_frame_to_datastack(tstate, src->frame, src->num_slots);
+        _aleff_frame_t *frame = push_frame_to_datastack(
+            tstate,
+            src->frame,
+            src->num_slots,
+            replacements
+        );
         if (frame == nullptr) {
             tstate->datastack_top = saved_datastack_top;
             Py_DECREF(pending);
@@ -1350,6 +1453,9 @@ _aleff_snapshot_from_frame(_ALEFF_UNUSED PyObject *self, PyObject *args)
             }
             snapshot->frames[i].handled_exception = Py_XNewRef(
                 _aleff_frame_handled_exception(internal, fallback_exception)
+            );
+            snapshot->frames[i].original_owner = Py_XNewRef(
+                _aleff_frame_generator_owner(internal)
             );
 
             PyFrameObject *prev = PyFrame_GetBack(f);

--- a/src/aleff/_multishot/v1/_aleff.c
+++ b/src/aleff/_multishot/v1/_aleff.c
@@ -15,7 +15,9 @@
 
 #define PY_SSIZE_T_CLEAN
 #include <Python.h>
+#include <compile.h>
 #include <frameobject.h>
+#include <limits.h>
 #include <stddef.h>
 #ifdef _WIN32
 #  define WIN32_LEAN_AND_MEAN
@@ -182,6 +184,7 @@ _aleff_init_opcode_deopt(void)
  * ======================================================================== */
 
 typedef uint16_t _aleff_codeunit;
+#define ALEFF_CODE_CODE(code) ((_aleff_codeunit *)((code)->co_code_adaptive))
 
 #if PY_VERSION_HEX >= 0x030e0000
 /* Python 3.14+: _PyStackRef fields */
@@ -417,6 +420,9 @@ typedef struct {
     int num_slots;          /* number of localsplus slots */
     PyObject *handled_exception;  /* effective handled exception, or nullptr */
     PyObject *original_owner;  /* generator/coroutine owner, or nullptr */
+    int send_stack_depth;  /* operand depth at an active SEND, or -1 */
+    int send_target_offset;  /* bytecode offset of END_SEND, or -1 */
+    int send_value_needs_pop;  /* C-level SEND still owns its sent value */
 } _aleff_frame_copy_t;
 
 typedef struct {
@@ -487,9 +493,17 @@ static PyTypeObject FrameSnapshotType = {
  * frame_obj is set to nullptr (not shared with the original).
  */
 static _aleff_frame_copy_t
-copy_single_frame(_aleff_frame_t *src)
+copy_single_frame(_aleff_frame_t *src, int send_stack_depth, int send_target_offset)
 {
-    _aleff_frame_copy_t result = {nullptr, 0, nullptr, nullptr};
+    _aleff_frame_copy_t result = {
+        .frame = nullptr,
+        .num_slots = 0,
+        .handled_exception = nullptr,
+        .original_owner = nullptr,
+        .send_stack_depth = send_stack_depth,
+        .send_target_offset = send_target_offset,
+        .send_value_needs_pop = -1,
+    };
 
     PyCodeObject *code = _aleff_frame_get_code(src);
     int num_slots = _aleff_frame_num_slots(code);
@@ -532,32 +546,33 @@ copy_single_frame(_aleff_frame_t *src)
     /* owner: mark as owned by thread (will be cleaned up manually) */
     dst->owner = FRAME_OWNED_BY_THREAD;
 
-    /* INCREF localsplus entries.
-     *
-     * CPython 3.12 sets stacktop = -1 while a frame is actively executing
-     * (the real stack pointer is kept in a register). stacktop is only
-     * written with a valid value when the frame is deactivated (yield, etc.).
-     *
-     * Since snapshot_frames() is called from within the eval loop,
-     * stacktop will be -1 for active frames. In this case we must
-     * INCREF all slots (locals + cells + value stack).
-     *
-     * When stacktop >= 0 (deactivated frame), only slots 0..stacktop-1
-     * are valid; the rest may contain stale pointers from POP(). */
-    /* INCREF localsplus entries.
-     *
-     * CPython 3.12 sets stacktop = -1 while a frame is actively executing
-     * (the real stack pointer lives in a register). In this case the
-     * value stack slots still contain valid PyObject pointers.
-     *
-     * When stacktop >= 0 (deactivated frame), slots 0..stacktop-1 are
-     * valid. Slots beyond stacktop may contain stale pointers left by
-     * the eval loop's POP() macro (which doesn't null popped slots). */
     /* When stacktop >= 0: slots 0..stacktop-1 are valid.
      * When stacktop == -1 (active frame): only locals/cells/freevars
      * (0..co_nlocalsplus-1) are safe. The value stack portion may
      * contain stale pointers from the eval loop. */
     int stacktop = _aleff_frame_stacktop(dst);
+    if (send_stack_depth >= 0) {
+        int send_entry_top = code->co_nlocalsplus + send_stack_depth;
+        if (send_entry_top > num_slots) {
+            PyErr_SetString(PyExc_RuntimeError, "active SEND stack exceeds frame capacity");
+            goto frame_header_error;
+        }
+        if (stacktop < 0) {
+            stacktop = send_entry_top;
+            _aleff_frame_set_stacktop(dst, stacktop);
+            result.send_value_needs_pop = 1;
+        }
+        else if (stacktop == send_entry_top) {
+            result.send_value_needs_pop = 1;
+        }
+        else if (stacktop == send_entry_top - 1) {
+            result.send_value_needs_pop = 0;
+        }
+        else {
+            PyErr_SetString(PyExc_RuntimeError, "operand stack does not match active SEND");
+            goto frame_header_error;
+        }
+    }
     int valid_slots = stacktop >= 0
         ? stacktop
         : code->co_nlocalsplus;
@@ -570,6 +585,15 @@ copy_single_frame(_aleff_frame_t *src)
 
     result.frame = dst;
     result.num_slots = num_slots;
+    return result;
+
+frame_header_error:
+    Py_XDECREF(ALEFF_GET_EXECUTABLE(dst));
+    Py_XDECREF(ALEFF_GET_FUNCOBJ(dst));
+    Py_XDECREF(dst->f_globals);
+    Py_XDECREF(dst->f_builtins);
+    Py_XDECREF(dst->f_locals);
+    PyMem_Free(dst);
     return result;
 }
 
@@ -647,7 +671,7 @@ create_snapshot(PyFrameObject *boundary_frame, int max_depth)
         for (int i = 0; i < count; i++) {
             _aleff_frame_t *internal = _aleff_frame_from_pyframe(f);
 
-            snapshot->frames[i] = copy_single_frame(internal);
+            snapshot->frames[i] = copy_single_frame(internal, -1, -1);
             if (snapshot->frames[i].frame == nullptr) {
                 snapshot->num_frames = i;
                 Py_DECREF(f);
@@ -973,7 +997,29 @@ generator_owner_from_frame_copy(
      * returned by an inlined child coroutine must resume after SEND, exactly
      * as CPython's RETURN_VALUE path does via the caller's return_offset. */
     if (resume_from_coroutine) {
-        ALEFF_PREV_INSTR(dst) += dst->return_offset;
+        if (src_copy->send_target_offset >= 0) {
+            int stacktop = _aleff_frame_stacktop(dst);
+            int minimum_top = code->co_nlocalsplus + 1 + src_copy->send_value_needs_pop;
+            if (stacktop < minimum_top) {
+                PyErr_SetString(PyExc_RuntimeError, "invalid operand stack for SEND completion");
+                Py_DECREF(py_frame);
+                return nullptr;
+            }
+            if (src_copy->send_value_needs_pop) {
+                stacktop--;
+                Py_XDECREF(ALEFF_LOCALSPLUS_GET(dst, stacktop));
+                ALEFF_LOCALSPLUS_SET(dst, stacktop, nullptr);
+                _aleff_frame_set_stacktop(dst, stacktop);
+            }
+#if PY_VERSION_HEX >= 0x030d0000
+            ALEFF_PREV_INSTR(dst) = ALEFF_CODE_CODE(code) + src_copy->send_target_offset / 2;
+#else
+            ALEFF_PREV_INSTR(dst) = ALEFF_CODE_CODE(code) + src_copy->send_target_offset / 2 - 1;
+#endif
+        }
+        else {
+            ALEFF_PREV_INSTR(dst) += dst->return_offset;
+        }
     }
     else {
         prepare_resume_frame(dst);
@@ -1081,6 +1127,16 @@ _aleff_restore_continuation(_ALEFF_UNUSED PyObject *self, PyObject *args)
     if (num <= 0) {
         PyErr_SetString(PyExc_ValueError, "no frames to restore");
         return nullptr;
+    }
+    for (int i = skip; i < snapshot->num_frames; i++) {
+        PyCodeObject *code = _aleff_frame_get_code(snapshot->frames[i].frame);
+        if (code->co_flags & CO_GENERATOR) {
+            PyErr_SetString(
+                PyExc_RuntimeError,
+                "synchronous generator frames are not supported by multi-shot restoration"
+            );
+            return nullptr;
+        }
     }
 
     PyThreadState *tstate = PyThreadState_Get();
@@ -1385,6 +1441,417 @@ PyDoc_STRVAR(snapshot_from_frame_doc,
 "  depth: Maximum number of frames to capture. -1 for all.\n"
 "  handled_exception: Active exception from the suspended caller, if any.\n");
 
+static int
+_aleff_read_exception_varint(
+    const unsigned char **cursor,
+    const unsigned char *end,
+    int *value
+)
+{
+    if (*cursor >= end) {
+        PyErr_SetString(PyExc_RuntimeError, "truncated exception table");
+        return -1;
+    }
+    unsigned int result = *(*cursor)++ & 63U;
+    while ((*cursor)[-1] & 64U) {
+        if (*cursor >= end || result > ((unsigned int)INT_MAX >> 6)) {
+            PyErr_SetString(PyExc_RuntimeError, "invalid exception table varint");
+            return -1;
+        }
+        result = (result << 6) | (*(*cursor)++ & 63U);
+    }
+    *value = (int)result;
+    return 0;
+}
+
+typedef struct {
+    int start;
+    int end;
+    int target;
+    int depth;
+    int lasti;
+} _aleff_exception_entry_t;
+
+static int
+_aleff_record_stack_depth(
+    int offset,
+    int depth,
+    int code_size,
+    int stack_size,
+    int *depths,
+    int *queue,
+    int *queue_end
+)
+{
+    if (
+        offset < 0 || offset >= code_size || offset % 2 != 0 ||
+        depth < 0 || depth > stack_size
+    ) {
+        PyErr_SetString(PyExc_RuntimeError, "invalid bytecode stack-depth edge");
+        return -1;
+    }
+    int index = offset / 2;
+    if (depths[index] == INT_MIN) {
+        depths[index] = depth;
+        queue[(*queue_end)++] = offset;
+    }
+    else if (depths[index] != depth) {
+        PyErr_SetString(PyExc_RuntimeError, "inconsistent bytecode stack depth");
+        return -1;
+    }
+    return 0;
+}
+
+static int
+_aleff_opcode_is_jump(int opcode)
+{
+    switch (opcode) {
+        case FOR_ITER:
+        case JUMP_FORWARD:
+        case POP_JUMP_IF_FALSE:
+        case POP_JUMP_IF_TRUE:
+        case POP_JUMP_IF_NOT_NONE:
+        case POP_JUMP_IF_NONE:
+        case JUMP_BACKWARD_NO_INTERRUPT:
+        case JUMP_BACKWARD:
+        case SEND:
+            return 1;
+        default:
+            return 0;
+    }
+}
+
+static int
+_aleff_opcode_is_backward_jump(int opcode)
+{
+    return opcode == JUMP_BACKWARD || opcode == JUMP_BACKWARD_NO_INTERRUPT;
+}
+
+static int
+_aleff_opcode_is_unconditional_jump(int opcode)
+{
+    return opcode == JUMP_FORWARD || _aleff_opcode_is_backward_jump(opcode);
+}
+
+static int
+_aleff_opcode_is_terminal(int opcode)
+{
+    switch (opcode) {
+        case RETURN_VALUE:
+#ifdef RETURN_CONST
+        case RETURN_CONST:
+#endif
+        case RAISE_VARARGS:
+        case RERAISE:
+            return 1;
+        default:
+            return 0;
+    }
+}
+
+static int
+_aleff_instruction_arg(
+    const unsigned char *bytecode,
+    int offset,
+    uint32_t *oparg
+)
+{
+    uint32_t result = bytecode[offset + 1];
+    int shift = 8;
+    for (int previous = offset - 2; previous >= 0 && bytecode[previous] == EXTENDED_ARG;
+         previous -= 2) {
+        if (shift >= 32) {
+            PyErr_SetString(PyExc_RuntimeError, "bytecode argument is too large");
+            return -1;
+        }
+        result |= (uint32_t)bytecode[previous + 1] << shift;
+        shift += 8;
+    }
+    *oparg = result;
+    return 0;
+}
+
+static int
+load_send_metadata(
+    PyFrameObject *frame,
+    int *stack_depth,
+    int *target_offset
+)
+{
+    int result = -1;
+    PyCodeObject *code = nullptr;
+    PyObject *code_bytes = nullptr;
+    int *depths = nullptr;
+    int *queue = nullptr;
+    _aleff_exception_entry_t *exception_entries = nullptr;
+    int code_size;
+    int instruction_count;
+    int exception_count = 0;
+
+    *stack_depth = -1;
+    *target_offset = -1;
+    code = (PyCodeObject *)PyFrame_GetCode(frame);
+    if (code == nullptr) {
+        goto done;
+    }
+    code_bytes = PyCode_GetCode(code);
+    if (code_bytes == nullptr) {
+        goto done;
+    }
+    Py_ssize_t byte_count = PyBytes_GET_SIZE(code_bytes);
+    if (byte_count <= 0 || byte_count > INT_MAX || byte_count % 2 != 0) {
+        PyErr_SetString(PyExc_RuntimeError, "invalid frame bytecode size");
+        goto done;
+    }
+    code_size = (int)byte_count;
+    const unsigned char *bytecode = (const unsigned char *)PyBytes_AS_STRING(code_bytes);
+    int send_offset = PyFrame_GetLasti(frame);
+    if (
+        send_offset < 0 || send_offset >= code_size || send_offset % 2 != 0 ||
+        bytecode[send_offset] != SEND
+    ) {
+        result = 0;
+        goto done;
+    }
+
+    uint32_t send_arg;
+    if (_aleff_instruction_arg(bytecode, send_offset, &send_arg) < 0) {
+        goto done;
+    }
+    int send_next = send_offset + 2;
+    while (send_next < code_size && bytecode[send_next] == CACHE) {
+        send_next += 2;
+    }
+    if (
+        send_arg > (uint32_t)((code_size - send_next) / 2) ||
+        send_next + (int)(send_arg * 2U) >= code_size
+    ) {
+        PyErr_SetString(PyExc_RuntimeError, "SEND jump exceeds frame bytecode");
+        goto done;
+    }
+    int send_target = send_next + (int)(send_arg * 2U);
+    if (bytecode[send_target] != END_SEND) {
+        PyErr_SetString(PyExc_RuntimeError, "SEND jump does not target END_SEND");
+        goto done;
+    }
+
+    instruction_count = code_size / 2;
+    depths = PyMem_Malloc((size_t)instruction_count * sizeof(*depths));
+    queue = PyMem_Malloc((size_t)instruction_count * sizeof(*queue));
+    if (depths == nullptr || queue == nullptr) {
+        PyErr_NoMemory();
+        goto done;
+    }
+    for (int i = 0; i < instruction_count; i++) {
+        depths[i] = INT_MIN;
+    }
+
+    PyObject *exception_table = code->co_exceptiontable;
+    if (!PyBytes_Check(exception_table)) {
+        PyErr_SetString(PyExc_RuntimeError, "invalid code exception table");
+        goto done;
+    }
+    Py_ssize_t exception_size = PyBytes_GET_SIZE(exception_table);
+    if (exception_size > INT_MAX) {
+        PyErr_SetString(PyExc_RuntimeError, "exception table is too large");
+        goto done;
+    }
+    if (exception_size > 0) {
+        Py_ssize_t maximum_entries = exception_size / 4 + 1;
+        exception_entries = PyMem_Malloc(
+            (size_t)maximum_entries * sizeof(*exception_entries)
+        );
+        if (exception_entries == nullptr) {
+            PyErr_NoMemory();
+            goto done;
+        }
+        const unsigned char *cursor =
+            (const unsigned char *)PyBytes_AS_STRING(exception_table);
+        const unsigned char *exception_end = cursor + exception_size;
+        while (cursor < exception_end) {
+            int start_units;
+            int length_units;
+            int target_units;
+            int depth_lasti;
+            if (
+                _aleff_read_exception_varint(&cursor, exception_end, &start_units) < 0 ||
+                _aleff_read_exception_varint(&cursor, exception_end, &length_units) < 0 ||
+                _aleff_read_exception_varint(&cursor, exception_end, &target_units) < 0 ||
+                _aleff_read_exception_varint(&cursor, exception_end, &depth_lasti) < 0
+            ) {
+                goto done;
+            }
+            if (
+                start_units > INT_MAX / 2 ||
+                length_units > INT_MAX / 2 - start_units ||
+                target_units > INT_MAX / 2
+            ) {
+                PyErr_SetString(PyExc_RuntimeError, "exception table entry is too large");
+                goto done;
+            }
+            _aleff_exception_entry_t *entry = &exception_entries[exception_count++];
+            entry->start = start_units * 2;
+            entry->end = entry->start + length_units * 2;
+            entry->target = target_units * 2;
+            entry->depth = depth_lasti >> 1;
+            entry->lasti = depth_lasti & 1;
+            if (
+                entry->end < entry->start || entry->end > code_size ||
+                entry->target < 0 || entry->target >= code_size ||
+                entry->depth < 0 ||
+                entry->depth > code->co_stacksize - 1 - entry->lasti
+            ) {
+                PyErr_SetString(PyExc_RuntimeError, "invalid exception table entry");
+                goto done;
+            }
+        }
+    }
+
+    int entry_offset = -1;
+    for (int offset = 0; offset < code_size; offset += 2) {
+        if (bytecode[offset] == RESUME && bytecode[offset + 1] == 0) {
+            entry_offset = offset;
+            break;
+        }
+    }
+    if (entry_offset < 0) {
+        PyErr_SetString(PyExc_RuntimeError, "frame bytecode has no entry RESUME");
+        goto done;
+    }
+
+    int queue_start = 0;
+    int queue_end = 0;
+    if (
+        _aleff_record_stack_depth(
+            entry_offset,
+            0,
+            code_size,
+            code->co_stacksize,
+            depths,
+            queue,
+            &queue_end
+        ) < 0
+    ) {
+        goto done;
+    }
+    while (queue_start < queue_end) {
+        int offset = queue[queue_start++];
+        int depth = depths[offset / 2];
+        int opcode = bytecode[offset];
+        uint32_t unsigned_arg;
+        if (_aleff_instruction_arg(bytecode, offset, &unsigned_arg) < 0) {
+            goto done;
+        }
+        if (unsigned_arg > INT_MAX) {
+            PyErr_SetString(PyExc_RuntimeError, "bytecode argument exceeds stack-effect API");
+            goto done;
+        }
+        int oparg = (int)unsigned_arg;
+        int next_offset = offset + 2;
+        while (next_offset < code_size && bytecode[next_offset] == CACHE) {
+            next_offset += 2;
+        }
+        int is_jump = _aleff_opcode_is_jump(opcode);
+        if (is_jump) {
+            int jump_effect = PyCompile_OpcodeStackEffectWithJump(opcode, oparg, 1);
+            if (jump_effect == PY_INVALID_STACK_EFFECT) {
+                PyErr_SetString(PyExc_RuntimeError, "invalid jump opcode stack effect");
+                goto done;
+            }
+            int64_t jump_distance = (int64_t)oparg * 2;
+            int64_t jump_target_wide = _aleff_opcode_is_backward_jump(opcode)
+                ? (int64_t)next_offset - jump_distance
+                : (int64_t)next_offset + jump_distance;
+            int64_t jump_depth_wide = (int64_t)depth + jump_effect;
+            if (
+                jump_target_wide < INT_MIN || jump_target_wide > INT_MAX ||
+                jump_depth_wide < INT_MIN || jump_depth_wide > INT_MAX
+            ) {
+                PyErr_SetString(PyExc_RuntimeError, "jump bytecode edge overflows");
+                goto done;
+            }
+            if (
+                _aleff_record_stack_depth(
+                    (int)jump_target_wide,
+                    (int)jump_depth_wide,
+                    code_size,
+                    code->co_stacksize,
+                    depths,
+                    queue,
+                    &queue_end
+                ) < 0
+            ) {
+                goto done;
+            }
+        }
+        if (!_aleff_opcode_is_terminal(opcode) && !_aleff_opcode_is_unconditional_jump(opcode)) {
+            int fallthrough_effect = PyCompile_OpcodeStackEffectWithJump(
+                opcode,
+                oparg,
+                is_jump ? 0 : -1
+            );
+            if (fallthrough_effect == PY_INVALID_STACK_EFFECT) {
+                PyErr_SetString(PyExc_RuntimeError, "invalid opcode stack effect");
+                goto done;
+            }
+            int64_t fallthrough_depth_wide = (int64_t)depth + fallthrough_effect;
+            if (fallthrough_depth_wide < INT_MIN || fallthrough_depth_wide > INT_MAX) {
+                PyErr_SetString(PyExc_RuntimeError, "fallthrough bytecode edge overflows");
+                goto done;
+            }
+            if (
+                next_offset < code_size &&
+                _aleff_record_stack_depth(
+                    next_offset,
+                    (int)fallthrough_depth_wide,
+                    code_size,
+                    code->co_stacksize,
+                    depths,
+                    queue,
+                    &queue_end
+                ) < 0
+            ) {
+                goto done;
+            }
+        }
+        for (int i = 0; i < exception_count; i++) {
+            _aleff_exception_entry_t *entry = &exception_entries[i];
+            if (entry->start <= offset && offset < entry->end) {
+                if (
+                    _aleff_record_stack_depth(
+                        entry->target,
+                        entry->depth + 1 + entry->lasti,
+                        code_size,
+                        code->co_stacksize,
+                        depths,
+                        queue,
+                        &queue_end
+                    ) < 0
+                ) {
+                    goto done;
+                }
+            }
+        }
+    }
+
+    int depth = depths[send_offset / 2];
+    if (depth < 2 || depth > code->co_stacksize) {
+        PyErr_SetString(PyExc_RuntimeError, "cannot determine operand stack depth at SEND");
+        goto done;
+    }
+    *stack_depth = depth;
+    *target_offset = send_target;
+    result = 0;
+
+done:
+    PyMem_Free(exception_entries);
+    PyMem_Free(queue);
+    PyMem_Free(depths);
+    Py_XDECREF(code_bytes);
+    Py_XDECREF(code);
+    return result;
+}
+
 static PyObject *
 _aleff_snapshot_from_frame(_ALEFF_UNUSED PyObject *self, PyObject *args)
 {
@@ -1443,8 +1910,20 @@ _aleff_snapshot_from_frame(_ALEFF_UNUSED PyObject *self, PyObject *args)
         Py_INCREF(f);
         for (int i = 0; i < count; i++) {
             _aleff_frame_t *internal = _aleff_frame_from_pyframe(f);
+            int send_stack_depth;
+            int send_target_offset;
+            if (load_send_metadata(f, &send_stack_depth, &send_target_offset) < 0) {
+                snapshot->num_frames = i;
+                Py_DECREF(f);
+                Py_DECREF(snapshot);
+                return nullptr;
+            }
 
-            snapshot->frames[i] = copy_single_frame(internal);
+            snapshot->frames[i] = copy_single_frame(
+                internal,
+                send_stack_depth,
+                send_target_offset
+            );
             if (snapshot->frames[i].frame == nullptr) {
                 snapshot->num_frames = i;
                 Py_DECREF(f);

--- a/src/aleff/_multishot/v1/_aleff.c
+++ b/src/aleff/_multishot/v1/_aleff.c
@@ -28,6 +28,10 @@
 #error "_aleff requires Python 3.12 or later"
 #endif
 
+#if PY_VERSION_HEX >= 0x030f0000
+#error "_aleff coroutine internals require review before supporting Python 3.15+"
+#endif
+
 /* MSVC /std:c17 does not support C23 [[maybe_unused]] or nullptr. */
 #if defined(_MSC_VER) && !defined(__cplusplus)
 #  define nullptr NULL
@@ -259,6 +263,29 @@ _aleff_frame_set_stacktop(_aleff_frame_t *frame, int top)
 #define FRAME_OWNED_BY_INTERPRETER 3
 #define FRAME_OWNED_BY_CSTACK 4
 
+/* PyCoroObject became opaque in the public CPython 3.14 headers.  Mirror the
+ * CPython 3.14 prefix through cr_frame_state; the explicit version guard near
+ * the top of this file requires this layout to be reviewed for Python 3.15. */
+typedef struct {
+    PyObject_HEAD
+    PyObject *cr_weakreflist;
+    PyObject *cr_name;
+    PyObject *cr_qualname;
+    _PyErr_StackItem cr_exc_state;
+    PyObject *cr_origin_or_finalizer;
+    char cr_hooks_inited;
+    char cr_closed;
+    char cr_running_async;
+    int8_t cr_frame_state;
+} _aleff_coro_prefix_t;
+
+#define ALEFF_SET_CORO_FRAME_STATE(coro, state) \
+    (((_aleff_coro_prefix_t *)(coro))->cr_frame_state = (state))
+#define ALEFF_CORO_EXC_STATE(coro) \
+    (&((_aleff_coro_prefix_t *)(coro))->cr_exc_state)
+#define ALEFF_CORO_FROM_FRAME(frame) \
+    ((_aleff_coro_prefix_t *)((char *)(frame) - sizeof(_aleff_coro_prefix_t)))
+
 #else
 /* Python 3.12-3.13: PyObject* fields */
 
@@ -298,7 +325,25 @@ _aleff_frame_set_stacktop(_aleff_frame_t *frame, int top)
 #define FRAME_OWNED_BY_FRAME_OBJECT 2
 #define FRAME_OWNED_BY_CSTACK 3
 
+#define ALEFF_SET_CORO_FRAME_STATE(coro, state) \
+    (((PyCoroObject *)(coro))->cr_frame_state = (state))
+#define ALEFF_CORO_EXC_STATE(coro) \
+    (&((PyCoroObject *)(coro))->cr_exc_state)
+#define ALEFF_CORO_FROM_FRAME(frame) \
+    ((PyCoroObject *)((char *)(frame) - offsetof(PyCoroObject, cr_iframe)))
+
 #endif /* PY_VERSION_HEX >= 0x030e0000 */
+
+static _aleff_frame_t *
+_aleff_frame_from_pyframe(PyFrameObject *frame)
+{
+    #define F_FRAME_OFFSET (sizeof(PyObject) + sizeof(PyFrameObject *))
+    _aleff_frame_t *internal = *(_aleff_frame_t **)(
+        (char *)frame + F_FRAME_OFFSET
+    );
+    #undef F_FRAME_OFFSET
+    return internal;
+}
 
 /* Accessors for f_executable and f_funcobj (PyObject* vs _PyStackRef) */
 #if PY_VERSION_HEX >= 0x030e0000
@@ -319,6 +364,39 @@ _aleff_frame_get_code(_aleff_frame_t *frame)
     return (PyCodeObject *)ALEFF_GET_EXECUTABLE(frame);
 }
 
+static PyObject *
+_aleff_effective_handled_exception(_PyErr_StackItem *item)
+{
+    while (item != nullptr) {
+        PyObject *exc = item->exc_value;
+        if (exc != nullptr && exc != Py_None) {
+            return exc;
+        }
+        item = item->previous_item;
+    }
+    return nullptr;
+}
+
+static inline int
+_aleff_is_exception_instance(PyObject *obj)
+{
+    return obj != nullptr && PyExceptionInstance_Check(obj);
+}
+
+static PyObject *
+_aleff_frame_handled_exception(_aleff_frame_t *frame, PyObject *fallback)
+{
+    PyCodeObject *code = _aleff_frame_get_code(frame);
+    if ((code->co_flags & CO_COROUTINE) && frame->owner == FRAME_OWNED_BY_GENERATOR) {
+        PyObject *coro = (PyObject *)ALEFF_CORO_FROM_FRAME(frame);
+        PyObject *exc = _aleff_effective_handled_exception(ALEFF_CORO_EXC_STATE(coro));
+        if (exc != nullptr) {
+            return exc;
+        }
+    }
+    return _aleff_is_exception_instance(fallback) ? fallback : nullptr;
+}
+
 static inline int
 _aleff_frame_num_slots(PyCodeObject *code)
 {
@@ -332,6 +410,7 @@ _aleff_frame_num_slots(PyCodeObject *code)
 typedef struct {
     _aleff_frame_t *frame;  /* deep-copied frame */
     int num_slots;          /* number of localsplus slots */
+    PyObject *handled_exception;  /* effective handled exception, or nullptr */
 } _aleff_frame_copy_t;
 
 typedef struct {
@@ -355,6 +434,7 @@ FrameSnapshot_dealloc(FrameSnapshotObject *self)
         Py_XDECREF(f->f_globals);
         Py_XDECREF(f->f_builtins);
         Py_XDECREF(f->f_locals);
+        Py_XDECREF(fc->handled_exception);
         /* Don't decref frame_obj — we set it to nullptr in copies */
 
         for (int j = 0; j < fc->num_slots; j++) {
@@ -402,7 +482,7 @@ static PyTypeObject FrameSnapshotType = {
 static _aleff_frame_copy_t
 copy_single_frame(_aleff_frame_t *src)
 {
-    _aleff_frame_copy_t result = {nullptr, 0};
+    _aleff_frame_copy_t result = {nullptr, 0, nullptr};
 
     PyCodeObject *code = _aleff_frame_get_code(src);
     int num_slots = _aleff_frame_num_slots(code);
@@ -551,22 +631,14 @@ create_snapshot(PyFrameObject *boundary_frame, int max_depth)
     }
     snapshot->num_frames = count;
 
-    /* Copy frames from innermost to outermost.
-     *
-     * In CPython 3.12, PyFrameObject layout is:
-     *   PyObject_HEAD           (16 bytes)
-     *   PyFrameObject *f_back   (8 bytes)
-     *   _PyInterpreterFrame *f_frame  (8 bytes)  <-- offset 24
-     */
-    #define F_FRAME_OFFSET (sizeof(PyObject) + sizeof(PyFrameObject *))
-
     {
+        PyObject *fallback_exception = _aleff_effective_handled_exception(
+            PyThreadState_Get()->exc_info
+        );
         PyFrameObject *f = py_frame;
         Py_INCREF(f);
         for (int i = 0; i < count; i++) {
-            _aleff_frame_t *internal = *(_aleff_frame_t **)(
-                (char *)f + F_FRAME_OFFSET
-            );
+            _aleff_frame_t *internal = _aleff_frame_from_pyframe(f);
 
             snapshot->frames[i] = copy_single_frame(internal);
             if (snapshot->frames[i].frame == nullptr) {
@@ -576,6 +648,9 @@ create_snapshot(PyFrameObject *boundary_frame, int max_depth)
                 Py_DECREF(py_frame);
                 return nullptr;
             }
+            snapshot->frames[i].handled_exception = Py_XNewRef(
+                _aleff_frame_handled_exception(internal, fallback_exception)
+            );
 
             PyFrameObject *prev = PyFrame_GetBack(f);  /* new ref */
             Py_DECREF(f);
@@ -583,8 +658,6 @@ create_snapshot(PyFrameObject *boundary_frame, int max_depth)
         }
         Py_XDECREF(f);  /* may be nullptr if chain ended */
     }
-
-    #undef F_FRAME_OFFSET
 
     Py_DECREF(py_frame);
 
@@ -626,8 +699,8 @@ static evalframe_fn_t _evalframe = nullptr;
  * In both cases, we set stacktop to co_nlocalsplus (value stack base)
  * before pushing, since the original stacktop may be -1 (invalid).
  */
-static void
-inject_resume_value(_aleff_frame_t *frame, PyObject *value)
+static int
+prepare_resume_frame(_aleff_frame_t *frame)
 {
     PyCodeObject *code = _aleff_frame_get_code(frame);
     int value_stack_base = code->co_nlocalsplus;
@@ -722,6 +795,15 @@ inject_resume_value(_aleff_frame_t *frame, PyObject *value)
 
     #undef CALL_TOTAL_SIZE
 
+    _aleff_frame_set_stacktop(frame, stacktop);
+    return stacktop;
+}
+
+static void
+inject_resume_value(_aleff_frame_t *frame, PyObject *value)
+{
+    int stacktop = prepare_resume_frame(frame);
+
     /* Push the resume value */
     Py_INCREF(value);
     ALEFF_LOCALSPLUS_SET(frame, stacktop, value);
@@ -777,6 +859,97 @@ push_frame_to_datastack(PyThreadState *tstate, _aleff_frame_t *src, int num_slot
     }
 
     return dst;
+}
+
+/* Build a real coroutine object around a copied suspended coroutine frame.
+ *
+ * PyCoro_New() only accepts a PyFrameObject.  Create a correctly-sized frame
+ * object, replace its freshly initialized interpreter frame with the snapshot
+ * state, then let PyCoro_New() move that state into coroutine-owned storage.
+ */
+static PyObject *
+coroutine_from_frame_copy(
+    PyThreadState *tstate,
+    _aleff_frame_copy_t *src_copy,
+    int resume_from_coroutine,
+    PyObject *handled_exception
+)
+{
+    _aleff_frame_t *src = src_copy->frame;
+    PyCodeObject *code = _aleff_frame_get_code(src);
+    PyFrameObject *py_frame = PyFrame_New(tstate, code, src->f_globals, src->f_locals);
+    if (py_frame == nullptr) {
+        return nullptr;
+    }
+
+    _aleff_frame_t *dst = _aleff_frame_from_pyframe(py_frame);
+
+    /* Release the empty frame state allocated by PyFrame_New().  Globals and
+     * builtins are borrowed by live frames and therefore are not decref'd. */
+    PyCodeObject *new_code = _aleff_frame_get_code(dst);
+    int initialized_slots = _aleff_frame_stacktop(dst);
+    if (initialized_slots < 0) {
+        initialized_slots = new_code->co_nlocalsplus;
+    }
+    Py_XDECREF(ALEFF_GET_EXECUTABLE(dst));
+    Py_XDECREF(ALEFF_GET_FUNCOBJ(dst));
+    Py_XDECREF(dst->f_locals);
+    for (int i = 0; i < initialized_slots; i++) {
+        Py_XDECREF(ALEFF_LOCALSPLUS_GET(dst, i));
+    }
+
+    size_t frame_size = sizeof(_aleff_frame_t)
+                      + (src_copy->num_slots - 1) * sizeof(PyObject *);
+    memcpy(dst, src, frame_size);
+
+#if PY_VERSION_HEX >= 0x030e0000
+    if (src->stackpointer != nullptr) {
+        ptrdiff_t sp_offset = src->stackpointer - src->localsplus;
+        dst->stackpointer = dst->localsplus + sp_offset;
+    }
+#endif
+
+    /* Match normal interpreter-frame ownership: executable, function,
+     * locals, and localsplus are strong; globals and builtins are borrowed. */
+    Py_XINCREF(ALEFF_GET_EXECUTABLE(dst));
+    Py_XINCREF(ALEFF_GET_FUNCOBJ(dst));
+    Py_XINCREF(dst->f_locals);
+    dst->frame_obj = nullptr;
+    dst->previous = nullptr;
+    dst->owner = FRAME_OWNED_BY_FRAME_OBJECT;
+    for (int i = 0; i < src_copy->num_slots; i++) {
+        Py_XINCREF(ALEFF_LOCALSPLUS_GET(dst, i));
+    }
+
+    /* coro.send(outcome) supplies the value that resumes this frame.  A value
+     * returned by an inlined child coroutine must resume after SEND, exactly
+     * as CPython's RETURN_VALUE path does via the caller's return_offset. */
+    if (resume_from_coroutine) {
+        ALEFF_PREV_INSTR(dst) += dst->return_offset;
+    }
+    else {
+        prepare_resume_frame(dst);
+    }
+
+    PyObject *coro = PyCoro_New(py_frame, code->co_name, code->co_qualname);
+    if (coro == nullptr) {
+        return nullptr;
+    }
+
+#if PY_VERSION_HEX >= 0x030d0000
+    ALEFF_SET_CORO_FRAME_STATE(coro, -2);  /* FRAME_SUSPENDED */
+#else
+    ALEFF_SET_CORO_FRAME_STATE(coro, -1);  /* FRAME_SUSPENDED */
+#endif
+    _PyErr_StackItem *exc_state = ALEFF_CORO_EXC_STATE(coro);
+    Py_XSETREF(
+        exc_state->exc_value,
+        _aleff_is_exception_instance(handled_exception)
+            ? Py_NewRef(handled_exception)
+            : nullptr
+    );
+    exc_state->previous_item = nullptr;
+    return coro;
 }
 
 /* ========================================================================
@@ -892,6 +1065,11 @@ _aleff_restore_continuation(_ALEFF_UNUSED PyObject *self, PyObject *args)
      * next outer frame using inject_resume_value, which handles both
      * inline dispatch and generic CALL stack states. */
     PyObject *result = nullptr;
+    _PyErr_StackItem restored_exc_state = {
+        .exc_value = Py_XNewRef(snapshot->frames[skip].handled_exception),
+        .previous_item = tstate->exc_info,
+    };
+    tstate->exc_info = &restored_exc_state;
 
     for (int i = 0; i < num; i++) {
         _aleff_frame_t *frame = frames_on_stack[i];
@@ -911,14 +1089,189 @@ _aleff_restore_continuation(_ALEFF_UNUSED PyObject *self, PyObject *args)
         }
     }
 
+    tstate->exc_info = restored_exc_state.previous_item;
+    restored_exc_state.previous_item = nullptr;
+    Py_XDECREF(restored_exc_state.exc_value);
+
     /* Restore the data stack top. */
     tstate->datastack_top = saved_datastack_top;
 
     return result;
 }
 
+static PyObject *
+make_async_restore_stage(
+    int done,
+    PyObject *payload,
+    int next_frame,
+    PyObject *initial,
+    int is_exception
+)
+{
+    PyObject *stage = PyTuple_New(5);
+    if (stage == nullptr) {
+        Py_DECREF(payload);
+        Py_DECREF(initial);
+        return nullptr;
+    }
+
+    PyTuple_SET_ITEM(stage, 0, PyBool_FromLong(done));
+    PyTuple_SET_ITEM(stage, 1, payload);
+    PyTuple_SET_ITEM(stage, 2, PyLong_FromLong(next_frame));
+    PyTuple_SET_ITEM(stage, 3, initial);
+    PyTuple_SET_ITEM(stage, 4, PyBool_FromLong(is_exception));
+
+    if (PyErr_Occurred()) {
+        Py_DECREF(stage);
+        return nullptr;
+    }
+    return stage;
+}
+
+PyDoc_STRVAR(restore_async_continuation_doc,
+"restore_async_continuation(\n"
+"    snapshot, outcome, start=1, is_exception=False, from_coroutine=False\n"
+")\n"
+"--\n\n"
+"Advance a restored frame chain until its next coroutine frame or completion.\n"
+"\n"
+"Coroutine frames are returned as independently-owned coroutine objects so\n"
+"their yield/return/raise protocol remains managed by CPython.  The returned\n"
+"tuple is (done, payload, next_frame, initial, is_exception).\n");
+
+static PyObject *
+_aleff_restore_async_continuation(_ALEFF_UNUSED PyObject *self, PyObject *args)
+{
+    FrameSnapshotObject *snapshot;
+    PyObject *outcome;
+    int start = 1;
+    int is_exception = 0;
+    int from_coroutine = 0;
+
+    if (!PyArg_ParseTuple(
+            args,
+            "O!O|ipp",
+            &FrameSnapshotType,
+            &snapshot,
+            &outcome,
+            &start,
+            &is_exception,
+            &from_coroutine
+        )) {
+        return nullptr;
+    }
+
+    if (_evalframe == nullptr) {
+        PyErr_SetString(PyExc_RuntimeError,
+            "_PyEval_EvalFrameDefault not available (dlsym failed at init)");
+        return nullptr;
+    }
+    if (start < 0 || start > snapshot->num_frames) {
+        PyErr_SetString(PyExc_ValueError, "invalid async continuation frame index");
+        return nullptr;
+    }
+
+    PyObject *pending = Py_NewRef(outcome);
+    int pending_is_exception = is_exception;
+    PyThreadState *tstate = PyThreadState_Get();
+    _PyErr_StackItem restored_exc_state = {
+        .exc_value = start < snapshot->num_frames
+            ? Py_XNewRef(snapshot->frames[start].handled_exception)
+            : nullptr,
+        .previous_item = tstate->exc_info,
+    };
+    tstate->exc_info = &restored_exc_state;
+    PyObject *return_value = nullptr;
+
+    for (int i = start; i < snapshot->num_frames; i++) {
+        _aleff_frame_copy_t *src = &snapshot->frames[i];
+        PyCodeObject *code = _aleff_frame_get_code(src->frame);
+
+        if (code->co_flags & CO_COROUTINE) {
+            PyObject *coro = coroutine_from_frame_copy(
+                tstate,
+                src,
+                from_coroutine && !pending_is_exception,
+                restored_exc_state.exc_value
+            );
+            if (coro == nullptr) {
+                Py_DECREF(pending);
+                goto done;
+            }
+            return_value = make_async_restore_stage(
+                0,
+                coro,
+                i + 1,
+                pending,
+                pending_is_exception
+            );
+            goto done;
+        }
+
+        PyObject **saved_datastack_top = tstate->datastack_top;
+        _aleff_frame_t *frame = push_frame_to_datastack(tstate, src->frame, src->num_slots);
+        if (frame == nullptr) {
+            tstate->datastack_top = saved_datastack_top;
+            Py_DECREF(pending);
+            goto done;
+        }
+        frame->previous = nullptr;
+
+        PyObject *result;
+        if (pending_is_exception) {
+            prepare_resume_frame(frame);
+            PyErr_SetRaisedException(pending);  /* steals pending */
+            pending = nullptr;
+            result = _evalframe(tstate, frame, 1);
+        }
+        else {
+            inject_resume_value(frame, pending);
+            Py_DECREF(pending);
+            pending = nullptr;
+            result = _evalframe(tstate, frame, 0);
+        }
+        tstate->datastack_top = saved_datastack_top;
+
+        if (result == nullptr) {
+            if (i + 1 >= snapshot->num_frames) {
+                goto done;
+            }
+            pending = PyErr_GetRaisedException();
+            if (pending == nullptr) {
+                PyErr_SetString(PyExc_RuntimeError,
+                    "restored frame failed without an active exception");
+                goto done;
+            }
+            pending_is_exception = 1;
+        }
+        else {
+            pending = result;
+            pending_is_exception = 0;
+        }
+        from_coroutine = 0;
+    }
+
+    if (pending_is_exception) {
+        PyErr_SetRaisedException(pending);  /* steals pending */
+        goto done;
+    }
+    return_value = make_async_restore_stage(
+        1,
+        pending,
+        snapshot->num_frames,
+        Py_NewRef(Py_None),
+        0
+    );
+
+done:
+    tstate->exc_info = restored_exc_state.previous_item;
+    restored_exc_state.previous_item = nullptr;
+    Py_XDECREF(restored_exc_state.exc_value);
+    return return_value;
+}
+
 PyDoc_STRVAR(snapshot_from_frame_doc,
-"snapshot_from_frame(frame, depth=-1)\n"
+"snapshot_from_frame(frame, depth=-1, handled_exception=None)\n"
 "--\n\n"
 "Capture a frame chain starting from the given frame object.\n"
 "The frame should be from a suspended greenlet (gr_frame) so that\n"
@@ -926,14 +1279,23 @@ PyDoc_STRVAR(snapshot_from_frame_doc,
 "\n"
 "Parameters:\n"
 "  frame: A frame object (e.g. greenlet.gr_frame).\n"
-"  depth: Maximum number of frames to capture. -1 for all.\n");
+"  depth: Maximum number of frames to capture. -1 for all.\n"
+"  handled_exception: Active exception from the suspended caller, if any.\n");
 
 static PyObject *
 _aleff_snapshot_from_frame(_ALEFF_UNUSED PyObject *self, PyObject *args)
 {
     PyFrameObject *start_frame;
     int depth = -1;
-    if (!PyArg_ParseTuple(args, "O!|i", &PyFrame_Type, &start_frame, &depth))
+    PyObject *fallback_exception = Py_None;
+    if (!PyArg_ParseTuple(
+            args,
+            "O!|iO",
+            &PyFrame_Type,
+            &start_frame,
+            &depth,
+            &fallback_exception
+        ))
         return nullptr;
 
     /* Count frames */
@@ -973,15 +1335,11 @@ _aleff_snapshot_from_frame(_ALEFF_UNUSED PyObject *self, PyObject *args)
     }
     snapshot->num_frames = count;
 
-    #define F_FRAME_OFFSET (sizeof(PyObject) + sizeof(PyFrameObject *))
-
     {
         PyFrameObject *f = start_frame;
         Py_INCREF(f);
         for (int i = 0; i < count; i++) {
-            _aleff_frame_t *internal = *(_aleff_frame_t **)(
-                (char *)f + F_FRAME_OFFSET
-            );
+            _aleff_frame_t *internal = _aleff_frame_from_pyframe(f);
 
             snapshot->frames[i] = copy_single_frame(internal);
             if (snapshot->frames[i].frame == nullptr) {
@@ -990,6 +1348,9 @@ _aleff_snapshot_from_frame(_ALEFF_UNUSED PyObject *self, PyObject *args)
                 Py_DECREF(snapshot);
                 return nullptr;
             }
+            snapshot->frames[i].handled_exception = Py_XNewRef(
+                _aleff_frame_handled_exception(internal, fallback_exception)
+            );
 
             PyFrameObject *prev = PyFrame_GetBack(f);
             Py_DECREF(f);
@@ -997,8 +1358,6 @@ _aleff_snapshot_from_frame(_ALEFF_UNUSED PyObject *self, PyObject *args)
         }
         Py_XDECREF(f);
     }
-
-    #undef F_FRAME_OFFSET
 
     /* Link copied frames */
     for (int i = 0; i < count - 1; i++) {
@@ -1037,9 +1396,7 @@ _aleff_debug_frame_stacktop(_ALEFF_UNUSED PyObject *self, PyObject *arg)
         PyErr_SetString(PyExc_TypeError, "expected a frame object");
         return nullptr;
     }
-    #define F_FRAME_OFFSET (sizeof(PyObject) + sizeof(PyFrameObject *))
-    _aleff_frame_t *iframe = *(_aleff_frame_t **)((char *)arg + F_FRAME_OFFSET);
-    #undef F_FRAME_OFFSET
+    _aleff_frame_t *iframe = _aleff_frame_from_pyframe((PyFrameObject *)arg);
     return PyLong_FromLong(_aleff_frame_stacktop(iframe));
 }
 
@@ -1052,6 +1409,12 @@ static PyMethodDef _aleff_methods[] = {
     {"snapshot_from_frame", _aleff_snapshot_from_frame, METH_VARARGS, snapshot_from_frame_doc},
     {"snapshot_num_frames", _aleff_snapshot_num_frames, METH_O, snapshot_num_frames_doc},
     {"restore_continuation", _aleff_restore_continuation, METH_VARARGS, restore_continuation_doc},
+    {
+        "restore_async_continuation",
+        _aleff_restore_async_continuation,
+        METH_VARARGS,
+        restore_async_continuation_doc
+    },
     {"_debug_frame_stacktop", _aleff_debug_frame_stacktop, METH_O, debug_frame_stacktop_doc},
     {nullptr, nullptr, 0, nullptr}
 };

--- a/src/aleff/_multishot/v1/_aleff.pyi
+++ b/src/aleff/_multishot/v1/_aleff.pyi
@@ -79,6 +79,7 @@ def restore_async_continuation[R, V](
     start: int = 1,
     is_exception: bool = False,
     from_coroutine: bool = False,
+    replacements: dict[object, object] | None = None,
 ) -> tuple[bool, object, int, object, bool]:
     """Advance restored frames to the next coroutine stage or completion."""
     ...

--- a/src/aleff/_multishot/v1/_aleff.pyi
+++ b/src/aleff/_multishot/v1/_aleff.pyi
@@ -27,7 +27,11 @@ def snapshot_frames(depth: int = -1) -> FrameSnapshot[Any, Any]:
     """
     ...
 
-def snapshot_from_frame(frame: types.FrameType, depth: int = -1) -> FrameSnapshot[Any, Any]:
+def snapshot_from_frame(
+    frame: types.FrameType,
+    depth: int = -1,
+    handled_exception: object = None,
+) -> FrameSnapshot[Any, Any]:
     """Capture a frame chain starting from the given frame object.
 
     The frame should be from a suspended greenlet (gr_frame) so that
@@ -36,6 +40,7 @@ def snapshot_from_frame(frame: types.FrameType, depth: int = -1) -> FrameSnapsho
     Parameters:
         frame: A frame object (e.g. greenlet.gr_frame).
         depth: Maximum number of frames to capture. -1 for all.
+        handled_exception: Active exception from the suspended caller, if any.
     """
     ...
 
@@ -66,6 +71,16 @@ def restore_continuation[R, V](snapshot: FrameSnapshot[R, V], value: R, skip: in
         RuntimeError: If _PyEval_EvalFrameDefault is not available.
         ValueError: If no frames remain after skipping.
     """
+    ...
+
+def restore_async_continuation[R, V](
+    snapshot: FrameSnapshot[R, V],
+    outcome: object,
+    start: int = 1,
+    is_exception: bool = False,
+    from_coroutine: bool = False,
+) -> tuple[bool, object, int, object, bool]:
+    """Advance restored frames to the next coroutine stage or completion."""
     ...
 
 HAS_RESTORE: int

--- a/src/aleff/_multishot/v1/effects.py
+++ b/src/aleff/_multishot/v1/effects.py
@@ -1,5 +1,6 @@
 from dataclasses import field, dataclass
 from functools import wraps
+from sys import exception as current_exception
 from typing import Any, Callable, cast, overload, Sequence
 import greenlet as gl
 from .intf import Effect, EffectNotHandledError
@@ -66,6 +67,8 @@ class EffectAborted(BaseException):
 ABORT = object()
 """Sentinel value switched into a caller greenlet to trigger EffectAborted."""
 
+_NO_HANDLED_EXCEPTION = object()
+
 
 def _make_effect(name: str) -> Effect[..., Any]:
     """Create a new effect as a plain Python function.
@@ -86,7 +89,15 @@ def _make_effect(name: str) -> Effect[..., Any]:
         handler_gl = gl.getcurrent().parent
         if handler_gl is None:
             raise EffectNotHandledError(eff)
-        result = handler_gl.switch(EffectContext(eff, args, kwargs))
+        handled_exception = current_exception()
+        result = handler_gl.switch(
+            EffectContext(
+                eff,
+                args,
+                kwargs,
+                handled_exception if handled_exception is not None else _NO_HANDLED_EXCEPTION,
+            )
+        )
         if result is ABORT:
             raise EffectAborted()
         return result
@@ -125,6 +136,7 @@ class EffectContext[**P, R]:
     effect: Effect[P, R]
     args: tuple[Any, ...] = ()
     kwargs: dict[str, Any] = field(default_factory=dict[str, Any])
+    handled_exception: object = field(default=_NO_HANDLED_EXCEPTION, repr=False, compare=False)
 
     def __repr__(self) -> str:
         return f"({eff_str(self.effect)} | args={self.args!r}, kwargs={self.kwargs!r})"

--- a/src/aleff/_multishot/v1/handlers.py
+++ b/src/aleff/_multishot/v1/handlers.py
@@ -17,7 +17,12 @@ from .intf import (
 )
 from .effects import EffectContext, ABORT, EffectAborted
 from .misc import debug, eff_str
-from ._aleff import FrameSnapshot, restore_continuation, snapshot_from_frame
+from ._aleff import (
+    FrameSnapshot,
+    restore_async_continuation,
+    restore_continuation,
+    snapshot_from_frame,
+)
 from .winds import capture_wind_stack, rewind
 
 
@@ -149,11 +154,13 @@ class _ResumeAsync[R, V](ResumeAsync[R, V]):
         snapshot: FrameSnapshot[R, V],
         token: object,
         handler: "_Handler[Any] | _AsyncHandler[Any]",
+        async_continuation: bool,
     ) -> None:
         self._caller_gl = caller_gl
         self._snapshot = snapshot
         self._token = token
         self._handler = handler
+        self._async_continuation = async_continuation
         self._winds = capture_wind_stack(caller_gl)
 
     async def __call__(self, value: R) -> V:
@@ -167,12 +174,12 @@ class _ResumeAsync[R, V](ResumeAsync[R, V]):
             caller_gl.parent = gl.getcurrent()
             try:
                 v = caller_gl.switch(value)
+                debug(f"||< @caller = {v!r}")
+                return await _drive_async(caller_gl, v)
             finally:
                 if not caller_gl.dead:
                     assert old_parent is not None
                     caller_gl.parent = old_parent
-            debug(f"||< @caller = {v!r}")
-            return await _drive_async(caller_gl, v)
 
         debug("||> @caller (multi-shot async)")
 
@@ -181,6 +188,8 @@ class _ResumeAsync[R, V](ResumeAsync[R, V]):
 
         def _body() -> V:
             rewind(winds)
+            if self._async_continuation:
+                return _run_restored_async_continuation(ss, value)
             return restore_continuation(ss, value)
 
         new_gl = gl.greenlet(_body)
@@ -293,7 +302,7 @@ def _drive_effect(caller_gl: Any, value: EffectContext[..., Any]) -> Any:
 
     # Take snapshot from the handler greenlet. The caller greenlet is
     # suspended at this point, so its frames have valid stacktop values.
-    snapshot = snapshot_from_frame(caller_gl.gr_frame)
+    snapshot = snapshot_from_frame(caller_gl.gr_frame, -1, value.handled_exception)
 
     resume: Resume[Any, Any] = _Resume(caller_gl, snapshot, d.token, d.handler)
     v = d.fn(resume, *d.args, **d.kwargs)
@@ -372,16 +381,19 @@ def _is_coroutine_request(v: Any) -> TypeGuard[_CoroutineRequest[Any]]:
     return isinstance(v, (_AwaitRequest, _BareYieldRequest))
 
 
-def _run_coroutine_in_bridge[V](coro: Coroutine[Any, Any, V]) -> V:
+def _run_coroutine_in_bridge[V](
+    coro: Coroutine[Any, Any, V],
+    initial: Any = None,
+    initial_is_exception: bool = False,
+) -> V:
     """Relay coroutine await requests and exceptions across a greenlet boundary."""
-    pending_exception: BaseException | None = None
-    parent = gl.getcurrent().parent
-    assert parent is not None
-
+    pending_exception = cast(BaseException, initial) if initial_is_exception else None
+    send_value = None if initial_is_exception else initial
     try:
         while True:
             if pending_exception is None:
-                awaitable = coro.send(None)
+                awaitable = coro.send(send_value)
+                send_value = None
             else:
                 exc = pending_exception
                 pending_exception = None
@@ -394,11 +406,59 @@ def _run_coroutine_in_bridge[V](coro: Coroutine[Any, Any, V]) -> V:
 
             request = _BARE_YIELD_REQUEST if awaitable is None else _AwaitRequest(awaitable)
             try:
+                parent = gl.getcurrent().parent
+                assert parent is not None
                 parent.switch(request)
             except BaseException as exc:
                 pending_exception = exc
     except StopIteration as exc:
         return cast(V, exc.value)
+
+
+def _run_restored_async_continuation[R, V](snapshot: FrameSnapshot[R, V], value: R) -> V:
+    """Drive independently restored coroutine frames from inner to outer."""
+    outcome: object = value
+    is_exception = False
+    from_coroutine = False
+    next_frame = 1
+
+    while True:
+        done, payload, next_frame, initial, initial_is_exception = restore_async_continuation(
+            snapshot,
+            outcome,
+            next_frame,
+            is_exception,
+            from_coroutine,
+        )
+        if done:
+            return cast(V, payload)
+
+        coro = cast(Coroutine[Any, Any, Any], payload)
+        try:
+            outcome = _run_coroutine_in_bridge(coro, initial, initial_is_exception)
+        except BaseException as exc:
+            outcome = exc
+            is_exception = True
+        else:
+            is_exception = False
+        from_coroutine = True
+
+
+def _snapshot_for_async_resume(
+    caller_gl: Any,
+    handled_exception: object,
+) -> tuple[FrameSnapshot[Any, Any], bool]:
+    """Exclude the C coroutine bridge from a restorable Python frame chain."""
+    start = caller_gl.gr_frame
+    frame = start
+    depth = 0
+    while frame is not None:
+        if frame.f_code is _run_coroutine_in_bridge.__code__:
+            return snapshot_from_frame(start, depth, handled_exception), True
+        depth += 1
+        frame = frame.f_back
+
+    return snapshot_from_frame(start, -1, handled_exception), False
 
 
 async def _resolve_coroutine_request(request: _CoroutineRequest[Any]) -> None:
@@ -492,7 +552,9 @@ async def _drive_async[V](
     # effect performed
     # switch to the handler greenlet
     # See _drive for why the abort belongs in a finally.
-    ctx = cast(EffectContext[..., Any], value)
+    if not _is_effect_context(value):
+        raise RuntimeError(f"invalid value passed to caller: {value!r}")
+    ctx = value
     try:
         return await _drive_effect_async(caller_gl, ctx, exclude_token)
     finally:
@@ -514,8 +576,14 @@ async def _drive_effect_async(
     if d.handler.shallow:
         _remove_all_handlers(d.token)
 
-    snapshot = snapshot_from_frame(caller_gl.gr_frame)
-    resume: ResumeAsync[Any, Any] = _ResumeAsync(caller_gl, snapshot, d.token, d.handler)
+    snapshot, async_continuation = _snapshot_for_async_resume(caller_gl, value.handled_exception)
+    resume: ResumeAsync[Any, Any] = _ResumeAsync(
+        caller_gl,
+        snapshot,
+        d.token,
+        d.handler,
+        async_continuation,
+    )
 
     # Use exclude_token so handler fn's effects skip this handler
     # (for deep handlers, entries stay on the stack for the caller).

--- a/src/aleff/_multishot/v1/handlers.py
+++ b/src/aleff/_multishot/v1/handlers.py
@@ -421,6 +421,7 @@ def _run_restored_async_continuation[R, V](snapshot: FrameSnapshot[R, V], value:
     is_exception = False
     from_coroutine = False
     next_frame = 1
+    replacements: dict[object, object] = {}
 
     while True:
         done, payload, next_frame, initial, initial_is_exception = restore_async_continuation(
@@ -429,6 +430,7 @@ def _run_restored_async_continuation[R, V](snapshot: FrameSnapshot[R, V], value:
             next_frame,
             is_exception,
             from_coroutine,
+            replacements,
         )
         if done:
             return cast(V, payload)

--- a/tests/test_aleff_c.py
+++ b/tests/test_aleff_c.py
@@ -9,7 +9,9 @@ import greenlet
 from aleff._multishot.v1._aleff import (
     FrameSnapshot,
     snapshot_frames,
+    snapshot_from_frame,
     snapshot_num_frames,
+    restore_async_continuation,
     restore_continuation,
     HAS_RESTORE,
 )
@@ -97,6 +99,23 @@ class TestSnapshotFrames:
         assert snapshot_num_frames(s1) == 1
         assert snapshot_num_frames(s2) == 1
         assert s1 is not s2
+
+
+class TestSnapshotFromFrame:
+    @pytest.mark.parametrize("handled_exception", [None, object()])
+    def test_non_exception_marker_is_treated_as_no_handled_exception(self, handled_exception: object):
+        parent = greenlet.getcurrent()
+
+        def suspend():
+            parent.switch()
+
+        child = greenlet.greenlet(suspend)
+        child.switch()
+        assert child.gr_frame is not None
+
+        snapshot = snapshot_from_frame(child.gr_frame, 1, handled_exception)
+
+        assert snapshot_num_frames(snapshot) == 1
 
 
 # ---------------------------------------------------------------------------
@@ -204,6 +223,33 @@ class TestRestoreContinuationErrors:
         assert HAS_RESTORE == 1, (
             "_PyEval_EvalFrameDefault was not found; restore_continuation will not work on this platform"
         )
+
+
+class TestRestoreAsyncContinuationErrors:
+    def test_negative_start_raises(self):
+        snapshot = snapshot_frames(1)
+
+        with pytest.raises(ValueError, match="invalid async continuation frame index"):
+            restore_async_continuation(snapshot, 42, -1)
+
+    def test_start_past_frame_count_raises(self):
+        snapshot = snapshot_frames(1)
+        frame_count = snapshot_num_frames(snapshot)
+
+        with pytest.raises(ValueError, match="invalid async continuation frame index"):
+            restore_async_continuation(snapshot, 42, frame_count + 1)
+
+    def test_start_at_frame_count_returns_completed_outcome(self):
+        snapshot = snapshot_frames(1)
+        frame_count = snapshot_num_frames(snapshot)
+
+        done, payload, next_frame, initial, is_exception = restore_async_continuation(snapshot, 42, frame_count)
+
+        assert done is True
+        assert payload == 42
+        assert next_frame == frame_count
+        assert initial is None
+        assert is_exception is False
 
 
 # ---------------------------------------------------------------------------

--- a/tests/test_aleff_c.py
+++ b/tests/test_aleff_c.py
@@ -1,6 +1,8 @@
 """Tests for the _aleff C extension (frame snapshot/restore)."""
 
 import sys
+import subprocess
+import textwrap
 from typing import Any
 
 import pytest
@@ -116,6 +118,72 @@ class TestSnapshotFromFrame:
         snapshot = snapshot_from_frame(child.gr_frame, 1, handled_exception)
 
         assert snapshot_num_frames(snapshot) == 1
+
+    def test_rejects_internal_send_metadata_argument(self):
+        parent = greenlet.getcurrent()
+
+        def suspend():
+            parent.switch()
+
+        child = greenlet.greenlet(suspend)
+        child.switch()
+        assert child.gr_frame is not None
+
+        with pytest.raises(TypeError, match="function takes at most 3 arguments"):
+            snapshot_from_frame(child.gr_frame, 1, None, [(2, 2147483646)])  # type: ignore[call-arg]
+
+    def test_send_stack_depth_does_not_depend_on_importable_python_analyzer(self):
+        code = textwrap.dedent(
+            """
+            import dis
+            import sys
+            import types
+
+            analyzer = types.ModuleType("aleff._multishot.v1._send_metadata")
+
+            def malicious_metadata(frame):
+                current = next(
+                    (
+                        instruction
+                        for instruction in dis.get_instructions(frame.f_code)
+                        if instruction.offset == frame.f_lasti
+                    ),
+                    None,
+                )
+                if current is None or current.opname != "SEND":
+                    return False, 0, 0
+                return True, frame.f_code.co_stacksize, current.argval
+
+            analyzer.send_stack_metadata = malicious_metadata
+            sys.modules[analyzer.__name__] = analyzer
+
+            import asyncio
+            from aleff import create_async_handler, effect
+
+            choose = effect("choose")
+            handler = create_async_handler(choose)
+
+            @handler.on(choose)
+            async def handle_choose(k):
+                return await k(1) + await k(2)
+
+            async def values():
+                yield choose()
+
+            async def run():
+                try:
+                    raise ValueError("enter exception handler")
+                except ValueError:
+                    iterator = values()
+                    return [10, 20, await anext(iterator)]
+
+            assert asyncio.run(handler(run)) == [10, 20, 1, 10, 20, 2]
+            """
+        )
+
+        result = subprocess.run([sys.executable, "-c", code], text=True, capture_output=True)
+
+        assert result.returncode == 0, result.stderr
 
 
 # ---------------------------------------------------------------------------
@@ -250,6 +318,13 @@ class TestRestoreAsyncContinuationErrors:
         assert next_frame == frame_count
         assert initial is None
         assert is_exception is False
+
+    def test_rejects_non_dict_replacements(self):
+        snapshot = snapshot_frames(1)
+        frame_count = snapshot_num_frames(snapshot)
+
+        with pytest.raises(TypeError, match="replacements must be a dict or None"):
+            restore_async_continuation(snapshot, 42, frame_count, False, False, [])  # type: ignore[arg-type]
 
 
 # ---------------------------------------------------------------------------

--- a/tests/test_multishot.py
+++ b/tests/test_multishot.py
@@ -5,6 +5,7 @@ each time resuming from the same suspension point with independent state.
 """
 
 import asyncio
+import sys
 from typing import Any
 
 import pytest
@@ -28,6 +29,55 @@ from aleff import (
 
 
 class TestMultiShotBasic:
+    def test_sync_caller_preserves_handled_exception_per_shot(self):
+        """Restored synchronous callers retain their handled exception."""
+        choose: Effect[[], int] = effect("choose")
+        h: Handler[list[tuple[int, str]]] = create_handler(choose)
+
+        @h.on(choose)
+        def _choose(k: Resume[int, list[tuple[int, str]]]):
+            return k(1) + k(2)
+
+        def run() -> list[tuple[int, str]]:
+            try:
+                raise ValueError("active")
+            except ValueError:
+                value = choose()
+                exc = sys.exception()
+                assert exc is not None
+                return [(value, str(exc))]
+
+        assert h(run) == [(1, "active"), (2, "active")]
+
+    def test_nested_sync_frames_preserve_distinct_handled_exceptions(self):
+        """Each restored synchronous frame retains its own handled exception."""
+        choose: Effect[[], int] = effect("choose")
+        h: Handler[list[tuple[int, str, str]]] = create_handler(choose)
+
+        @h.on(choose)
+        def _choose(k: Resume[int, list[tuple[int, str, str]]]):
+            return k(1) + k(2)
+
+        def inner() -> tuple[int, str]:
+            try:
+                raise KeyError("inner")
+            except KeyError:
+                value = choose()
+                exc = sys.exception()
+                assert exc is not None
+                return value, type(exc).__name__
+
+        def run() -> list[tuple[int, str, str]]:
+            try:
+                raise ValueError("outer")
+            except ValueError:
+                value, inner_exception = inner()
+                exc = sys.exception()
+                assert exc is not None
+                return [(value, inner_exception, type(exc).__name__)]
+
+        assert h(run) == [(1, "KeyError", "ValueError"), (2, "KeyError", "ValueError")]
+
     def test_resume_twice(self):
         """k can be called twice, each resuming from the same point."""
         choose: Effect[[], int] = effect("choose")
@@ -618,6 +668,393 @@ class TestMultiShotEdgeCases:
 
 
 class TestMultiShotAsync:
+    @pytest.mark.asyncio
+    async def test_async_caller_preserves_handled_exception_per_shot(self):
+        """Each restored shot retains the caller's handled exception."""
+        choose: Effect[[], int] = effect("choose")
+        h: AsyncHandler[list[tuple[int, str]]] = create_async_handler(choose)
+
+        @h.on(choose)
+        async def _choose(k: ResumeAsync[int, list[tuple[int, str]]]):
+            return await k(1) + await k(2) + await k(3)
+
+        async def run() -> list[tuple[int, str]]:
+            try:
+                raise ValueError("active")
+            except ValueError:
+                value = choose()
+                exc = sys.exception()
+                assert exc is not None
+                return [(value, str(exc))]
+
+        assert await h(run) == [(1, "active"), (2, "active"), (3, "active")]
+
+    @pytest.mark.asyncio
+    async def test_async_caller_bare_raise_uses_handled_exception_per_shot(self):
+        """A bare raise after resume re-raises the caller's active exception."""
+        choose: Effect[[], int] = effect("choose")
+        h: AsyncHandler[list[str]] = create_async_handler(choose)
+
+        @h.on(choose)
+        async def _choose(k: ResumeAsync[int, list[str]]):
+            messages: list[str] = []
+            for value in (1, 2):
+                try:
+                    await k(value)
+                except ValueError as exc:
+                    messages.append(str(exc))
+            return messages
+
+        async def run() -> list[str]:
+            try:
+                raise ValueError("active")
+            except ValueError:
+                choose()
+                raise
+
+        assert await h(run) == ["active", "active"]
+
+    @pytest.mark.asyncio
+    async def test_handler_exception_context_does_not_leak_into_caller(self):
+        """A handler's active exception is not inherited by restored callers."""
+        choose: Effect[[], int] = effect("choose")
+        h: AsyncHandler[list[BaseException | None]] = create_async_handler(choose)
+
+        @h.on(choose)
+        async def _choose(k: ResumeAsync[int, list[BaseException | None]]):
+            try:
+                raise ValueError("handler")
+            except ValueError:
+                return await k(1) + await k(2)
+
+        async def run() -> list[BaseException | None]:
+            choose()
+            return [sys.exception()]
+
+        assert await h(run) == [None, None]
+
+    @pytest.mark.asyncio
+    async def test_nested_coroutines_preserve_distinct_handled_exceptions(self):
+        """Each restored coroutine frame retains its own handled exception."""
+        choose: Effect[[], int] = effect("choose")
+        h: AsyncHandler[list[tuple[int, str, str]]] = create_async_handler(choose)
+
+        @h.on(choose)
+        async def _choose(k: ResumeAsync[int, list[tuple[int, str, str]]]):
+            return await k(1) + await k(2)
+
+        async def inner() -> tuple[int, str]:
+            try:
+                raise KeyError("inner")
+            except KeyError:
+                value = choose()
+                exc = sys.exception()
+                assert exc is not None
+                return value, type(exc).__name__
+
+        async def run() -> list[tuple[int, str, str]]:
+            try:
+                raise ValueError("outer")
+            except ValueError:
+                value, inner_exception = await inner()
+                exc = sys.exception()
+                assert exc is not None
+                return [(value, inner_exception, type(exc).__name__)]
+
+        assert await h(run) == [(1, "KeyError", "ValueError"), (2, "KeyError", "ValueError")]
+
+    @pytest.mark.asyncio
+    async def test_nested_coroutine_inherits_outer_handled_exception(self):
+        """A restored inner coroutine sees an exception handled by its awaiter."""
+        choose: Effect[[], int] = effect("choose")
+        h: AsyncHandler[list[tuple[int, str]]] = create_async_handler(choose)
+
+        @h.on(choose)
+        async def _choose(k: ResumeAsync[int, list[tuple[int, str]]]):
+            return await k(1) + await k(2)
+
+        async def inner() -> tuple[int, str]:
+            value = choose()
+            exc = sys.exception()
+            assert exc is not None
+            return value, type(exc).__name__
+
+        async def run() -> list[tuple[int, str]]:
+            try:
+                raise ValueError("outer")
+            except ValueError:
+                return [await inner()]
+
+        assert await h(run) == [(1, "ValueError"), (2, "ValueError")]
+
+    @pytest.mark.asyncio
+    async def test_async_caller_with_sync_helper_preserves_distinct_handled_exceptions(self):
+        """A sync helper and its async caller restore their own exception states."""
+        choose: Effect[[], int] = effect("choose")
+        h: AsyncHandler[list[tuple[int, str, str]]] = create_async_handler(choose)
+
+        @h.on(choose)
+        async def _choose(k: ResumeAsync[int, list[tuple[int, str, str]]]):
+            return await k(1) + await k(2)
+
+        def inner() -> tuple[int, str]:
+            try:
+                raise KeyError("inner")
+            except KeyError:
+                value = choose()
+                exc = sys.exception()
+                assert exc is not None
+                return value, type(exc).__name__
+
+        async def run() -> list[tuple[int, str, str]]:
+            try:
+                raise ValueError("outer")
+            except ValueError:
+                value, inner_exception = inner()
+                exc = sys.exception()
+                assert exc is not None
+                return [(value, inner_exception, type(exc).__name__)]
+
+        assert await h(run) == [(1, "KeyError", "ValueError"), (2, "KeyError", "ValueError")]
+
+    @pytest.mark.asyncio
+    async def test_async_caller_preserves_implicit_exception_chaining(self):
+        """New errors raised after resume retain the caller's handled exception as context."""
+        choose: Effect[[], int] = effect("choose")
+        h: AsyncHandler[list[tuple[str, str]]] = create_async_handler(choose)
+
+        @h.on(choose)
+        async def _choose(k: ResumeAsync[int, list[tuple[str, str]]]):
+            results: list[tuple[str, str]] = []
+            for value in (1, 2):
+                try:
+                    await k(value)
+                except RuntimeError as exc:
+                    assert exc.__context__ is not None
+                    results.append((str(exc), type(exc.__context__).__name__))
+            return results
+
+        async def run() -> list[tuple[str, str]]:
+            try:
+                raise ValueError("active")
+            except ValueError:
+                value = choose()
+                raise RuntimeError(f"shot: {value}")
+
+        assert await h(run) == [("shot: 1", "ValueError"), ("shot: 2", "ValueError")]
+
+    @pytest.mark.asyncio
+    @pytest.mark.parametrize(
+        ("shots", "expected"),
+        [(0, []), (1, [0]), (2, [0, 1]), (3, [0, 1, 2])],
+    )
+    async def test_async_caller_resume_many_times(self, shots: int, expected: list[int]):
+        """An async caller can be resumed zero, one, or many times."""
+        choose: Effect[[], int] = effect("choose")
+        h: AsyncHandler[list[int]] = create_async_handler(choose)
+
+        @h.on(choose)
+        async def _choose(k: ResumeAsync[int, list[int]]):
+            results: list[int] = []
+            for value in range(shots):
+                results.extend(await k(value))
+            return results
+
+        async def run() -> list[int]:
+            return [choose()]
+
+        assert await h(run) == expected
+
+    @pytest.mark.asyncio
+    @pytest.mark.parametrize("delay", [0, 0.001], ids=["bare-yield", "future"])
+    async def test_async_caller_awaits_after_effect_per_shot(self, delay: float):
+        """Each restored async caller independently completes a later await."""
+        choose: Effect[[], int] = effect("choose")
+        h: AsyncHandler[list[int]] = create_async_handler(choose)
+        completed: list[int] = []
+
+        @h.on(choose)
+        async def _choose(k: ResumeAsync[int, list[int]]):
+            return await k(1) + await k(2)
+
+        async def run():
+            value = choose()
+            await asyncio.sleep(delay)
+            completed.append(value)
+            return [value]
+
+        assert await h(run) == [1, 2]
+        assert completed == [1, 2]
+
+    @pytest.mark.asyncio
+    async def test_async_caller_exception_after_effect_isolated_per_shot(self):
+        """An exception from one restored caller does not corrupt another shot."""
+        choose: Effect[[], int] = effect("choose")
+        h: AsyncHandler[list[int | str]] = create_async_handler(choose)
+
+        @h.on(choose)
+        async def _choose(k: ResumeAsync[int, list[int | str]]):
+            results: list[int | str] = []
+            for value in (1, 2, 3):
+                try:
+                    results.extend(await k(value))
+                except ValueError as exc:
+                    results.append(str(exc))
+            return results
+
+        async def run() -> list[int | str]:
+            value = choose()
+            await asyncio.sleep(0)
+            if value == 2:
+                raise ValueError("bad shot: 2")
+            return [value]
+
+        assert await h(run) == [1, "bad shot: 2", 3]
+
+    @pytest.mark.asyncio
+    async def test_async_caller_restores_nested_coroutine_frames(self):
+        """Nested coroutine frames are restored from inner to outer per shot."""
+        choose: Effect[[], int] = effect("choose")
+        h: AsyncHandler[list[int]] = create_async_handler(choose)
+
+        @h.on(choose)
+        async def _choose(k: ResumeAsync[int, list[int]]):
+            return await k(1) + await k(2)
+
+        async def inner():
+            value = choose()
+            await asyncio.sleep(0)
+            return value
+
+        async def run():
+            return [10 + await inner()]
+
+        assert await h(run) == [11, 12]
+
+    @pytest.mark.asyncio
+    async def test_async_caller_restores_sync_helper_before_coroutine_frame(self):
+        """Synchronous frames below an async caller are restored first."""
+        choose: Effect[[], int] = effect("choose")
+        h: AsyncHandler[list[int]] = create_async_handler(choose)
+
+        @h.on(choose)
+        async def _choose(k: ResumeAsync[int, list[int]]):
+            return await k(1) + await k(2)
+
+        def inner():
+            return choose()
+
+        async def run():
+            value = inner()
+            await asyncio.sleep(0)
+            return [value]
+
+        assert await h(run) == [1, 2]
+
+    @pytest.mark.asyncio
+    async def test_async_caller_throws_nested_coroutine_error_into_outer_frame(self):
+        """An inner restored coroutine error reaches the outer async frame."""
+        choose: Effect[[], int] = effect("choose")
+        h: AsyncHandler[list[int | str]] = create_async_handler(choose)
+
+        @h.on(choose)
+        async def _choose(k: ResumeAsync[int, list[int | str]]):
+            return await k(1) + await k(2)
+
+        async def inner():
+            value = choose()
+            await asyncio.sleep(0)
+            if value == 2:
+                raise ValueError("nested: 2")
+            return value
+
+        async def run() -> list[int | str]:
+            try:
+                return [await inner()]
+            except ValueError as exc:
+                return [str(exc)]
+
+        assert await h(run) == [1, "nested: 2"]
+
+    @pytest.mark.asyncio
+    async def test_async_caller_restores_three_nested_coroutine_frames(self):
+        """Coroutine completion is relayed through every restored await frame."""
+        choose: Effect[[], int] = effect("choose")
+        h: AsyncHandler[list[int]] = create_async_handler(choose)
+
+        @h.on(choose)
+        async def _choose(k: ResumeAsync[int, list[int]]):
+            return await k(1) + await k(2)
+
+        async def leaf():
+            value = choose()
+            await asyncio.sleep(0)
+            return value
+
+        async def middle():
+            return 10 + await leaf()
+
+        async def run():
+            return [100 + await middle()]
+
+        assert await h(run) == [111, 112]
+
+    @pytest.mark.asyncio
+    async def test_async_caller_composes_two_multishot_effects(self):
+        """Two effects in an async caller produce their cartesian product."""
+        choose: Effect[[], int] = effect("choose")
+        h: AsyncHandler[list[tuple[int, int]]] = create_async_handler(choose)
+
+        @h.on(choose)
+        async def _choose(k: ResumeAsync[int, list[tuple[int, int]]]):
+            return await k(0) + await k(1)
+
+        async def run():
+            first = choose()
+            await asyncio.sleep(0)
+            second = choose()
+            await asyncio.sleep(0)
+            return [(first, second)]
+
+        assert await h(run) == [(0, 0), (0, 1), (1, 0), (1, 1)]
+
+    @pytest.mark.asyncio
+    async def test_async_caller_catches_awaitable_error_per_shot(self):
+        """Each restored caller receives errors from its own awaitable."""
+        choose: Effect[[], int] = effect("choose")
+        h: AsyncHandler[list[str]] = create_async_handler(choose)
+
+        @h.on(choose)
+        async def _choose(k: ResumeAsync[int, list[str]]):
+            return await k(1) + await k(2)
+
+        async def run() -> list[str]:
+            value = choose()
+            future: asyncio.Future[None] = asyncio.get_running_loop().create_future()
+            asyncio.get_running_loop().call_soon(future.set_exception, ValueError(f"future: {value}"))
+            try:
+                await future
+            except ValueError as exc:
+                return [str(exc)]
+            pytest.fail("the Future error was not thrown into the restored caller")
+
+        assert await h(run) == ["future: 1", "future: 2"]
+
+    @pytest.mark.asyncio
+    async def test_async_caller_resume_many_times_with_shallow_handler(self):
+        """A shallow async handler can resume one captured occurrence repeatedly."""
+        choose: Effect[[], int] = effect("choose")
+        h: AsyncHandler[list[int]] = create_async_handler(choose, shallow=True)
+
+        @h.on(choose)
+        async def _choose(k: ResumeAsync[int, list[int]]):
+            return await k(1) + await k(2)
+
+        async def run() -> list[int]:
+            return [choose()]
+
+        assert await h(run) == [1, 2]
+
     @pytest.mark.asyncio
     async def test_async_resume_twice(self):
         """Async handler can call k(value) multiple times."""

--- a/tests/test_multishot.py
+++ b/tests/test_multishot.py
@@ -5,6 +5,8 @@ each time resuming from the same suspension point with independent state.
 """
 
 import asyncio
+from collections.abc import Generator
+import dis
 import subprocess
 import sys
 import textwrap
@@ -81,7 +83,7 @@ class TestMultiShotBasic:
 
         assert h(run) == [(1, "KeyError", "ValueError"), (2, "KeyError", "ValueError")]
 
-    def test_sync_generator_frame_is_restored_with_generator_ownership(self):
+    def test_sync_generator_frame_is_rejected_without_crashing(self):
         code = textwrap.dedent(
             """
             from aleff import Handler, Resume, create_handler, effect
@@ -102,7 +104,12 @@ class TestMultiShotBasic:
                 iterator = values()
                 return [next(iterator), next(iterator)]
 
-            assert handler(run) == [1, 11, 2, 12]
+            try:
+                handler(run)
+            except RuntimeError as exc:
+                assert str(exc) == "synchronous generator frames are not supported by multi-shot restoration"
+            else:
+                raise AssertionError("expected an explicit unsupported-frame error")
             """
         )
 
@@ -323,7 +330,7 @@ class TestMultiShotNested:
         def _get_base(k: Resume[int, list[int]]):
             return k(100)
 
-        def inner():
+        def inner() -> list[int]:
             h_inner: Handler[list[int]] = create_handler(choose)
 
             @h_inner.on(choose)
@@ -880,7 +887,7 @@ class TestMultiShotAsync:
             return await k(1) + await k(2)
 
         @types.coroutine
-        def inner():
+        def inner() -> Generator[Any, Any, int]:
             value = choose()
             if False:
                 yield None
@@ -901,7 +908,7 @@ class TestMultiShotAsync:
             return await k(1) + await k(2)
 
         @types.coroutine
-        def inner():
+        def inner() -> Generator[Any, Any, int]:
             value = choose()
             yield None
             return value
@@ -910,6 +917,31 @@ class TestMultiShotAsync:
             return [await inner()]
 
         assert await h(run) == [1, 2]
+
+    @pytest.mark.asyncio
+    async def test_generator_based_coroutine_await_and_error_after_effect_per_shot(self):
+        choose: Effect[[], int] = effect("choose")
+        h: AsyncHandler[list[int | str]] = create_async_handler(choose)
+
+        @h.on(choose)
+        async def _choose(k: ResumeAsync[int, list[int | str]]):
+            return await k(1) + await k(2)
+
+        @types.coroutine
+        def inner() -> Generator[Any, Any, int]:
+            value = choose()
+            yield from asyncio.sleep(0).__await__()
+            if value == 2:
+                raise ValueError("bad shot: 2")
+            return value
+
+        async def run() -> list[int | str]:
+            try:
+                return [await inner()]
+            except ValueError as exc:
+                return [str(exc)]
+
+        assert await h(run) == [1, "bad shot: 2"]
 
     def test_async_generator_frame_is_restored_with_async_generator_ownership(self):
         code = textwrap.dedent(
@@ -935,6 +967,128 @@ class TestMultiShotAsync:
 
             async def main():
                 assert await handler(run) == [1, 11, 2, 12]
+
+            asyncio.run(main())
+            """
+        )
+
+        result = subprocess.run([sys.executable, "-c", code], text=True, capture_output=True)
+
+        assert result.returncode == 0, result.stderr
+
+    @pytest.mark.asyncio
+    async def test_async_generator_effect_is_restored_through_async_for(self):
+        choose: Effect[[], int] = effect("choose")
+        h: AsyncHandler[list[int]] = create_async_handler(choose)
+
+        @h.on(choose)
+        async def _choose(k: ResumeAsync[int, list[int]]):
+            return await k(1) + await k(2)
+
+        async def values():
+            yield choose()
+
+        async def run() -> list[int]:
+            result: tuple[int, ...] = ()
+            async for value in values():
+                result += (value,)
+            return list(result)
+
+        assert await h(run) == [1, 2]
+
+    @pytest.mark.asyncio
+    async def test_async_generator_effect_with_extended_jump_arguments(self):
+        choose: Effect[[], int] = effect("choose")
+        h: AsyncHandler[list[int]] = create_async_handler(choose)
+
+        @h.on(choose)
+        async def _choose(k: ResumeAsync[int, list[int]]):
+            return await k(1) + await k(2)
+
+        async def values():
+            yield choose()
+
+        padding = "\n".join(["        total += 0"] * 300)
+        source = f"""
+async def run():
+    total = 0
+    if padding_enabled:
+{padding}
+    while total < 1:
+{padding}
+        total += 1
+    try:
+{padding}
+        raise ValueError("enter exception handler")
+    except ValueError:
+        iterator = values()
+        return [await anext(iterator)]
+"""
+        namespace: dict[str, Any] = {
+            "anext": anext,
+            "padding_enabled": False,
+            "values": values,
+        }
+        exec(source, namespace)
+        run = namespace["run"]
+        instructions = list(dis.get_instructions(run))
+
+        assert any(instruction.opname == "EXTENDED_ARG" for instruction in instructions)
+        assert any(
+            instruction.opcode in dis.hasjrel
+            and isinstance(instruction.argval, int)
+            and instruction.argval > instruction.offset
+            and instruction.arg is not None
+            and instruction.arg > 255
+            for instruction in instructions
+        )
+        assert any(
+            instruction.opname.startswith("JUMP_BACKWARD") and instruction.arg is not None and instruction.arg > 255
+            for instruction in instructions
+        )
+        assert await h(run) == [1, 2]
+
+    def test_async_generator_asend_and_athrow_are_restored_per_shot(self):
+        code = textwrap.dedent(
+            """
+            import asyncio
+            from aleff import create_async_handler, effect
+
+            choose = effect("choose")
+            handler = create_async_handler(choose)
+
+            @handler.on(choose)
+            async def handle_choose(k):
+                return await k(1) + await k(2)
+
+            async def asend_values():
+                sent = yield 0
+                value = choose()
+                yield sent + value
+
+            async def run_asend():
+                iterator = asend_values()
+                first = await anext(iterator)
+                second = await iterator.asend(10)
+                await iterator.aclose()
+                return [(first, second)]
+
+            async def athrow_values():
+                try:
+                    yield 0
+                except ValueError:
+                    yield choose()
+
+            async def run_athrow():
+                iterator = athrow_values()
+                first = await anext(iterator)
+                second = await iterator.athrow(ValueError("injected"))
+                await iterator.aclose()
+                return [(first, second)]
+
+            async def main():
+                assert await handler(run_asend) == [(0, 11), (0, 12)]
+                assert await handler(run_athrow) == [(0, 1), (0, 2)]
 
             asyncio.run(main())
             """

--- a/tests/test_multishot.py
+++ b/tests/test_multishot.py
@@ -1008,7 +1008,7 @@ class TestMultiShotAsync:
         async def values():
             yield choose()
 
-        padding = "\n".join(["        total += 0"] * 300)
+        padding = "\n".join(["        total += 0"] * 14_000)
         source = f"""
 async def run():
     total = 0
@@ -1032,18 +1032,26 @@ async def run():
         exec(source, namespace)
         run = namespace["run"]
         instructions = list(dis.get_instructions(run))
+        maximum_extended_arg_run = 0
+        extended_arg_run = 0
+        for instruction in instructions:
+            if instruction.opname == "EXTENDED_ARG":
+                extended_arg_run += 1
+                maximum_extended_arg_run = max(maximum_extended_arg_run, extended_arg_run)
+            else:
+                extended_arg_run = 0
 
-        assert any(instruction.opname == "EXTENDED_ARG" for instruction in instructions)
+        assert maximum_extended_arg_run >= 2
         assert any(
             instruction.opcode in dis.hasjrel
             and isinstance(instruction.argval, int)
             and instruction.argval > instruction.offset
             and instruction.arg is not None
-            and instruction.arg > 255
+            and instruction.arg > 65_535
             for instruction in instructions
         )
         assert any(
-            instruction.opname.startswith("JUMP_BACKWARD") and instruction.arg is not None and instruction.arg > 255
+            instruction.opname.startswith("JUMP_BACKWARD") and instruction.arg is not None and instruction.arg > 65_535
             for instruction in instructions
         )
         assert await h(run) == [1, 2]

--- a/tests/test_multishot.py
+++ b/tests/test_multishot.py
@@ -5,7 +5,10 @@ each time resuming from the same suspension point with independent state.
 """
 
 import asyncio
+import subprocess
 import sys
+import textwrap
+import types
 from typing import Any
 
 import pytest
@@ -77,6 +80,35 @@ class TestMultiShotBasic:
                 return [(value, inner_exception, type(exc).__name__)]
 
         assert h(run) == [(1, "KeyError", "ValueError"), (2, "KeyError", "ValueError")]
+
+    def test_sync_generator_frame_is_restored_with_generator_ownership(self):
+        code = textwrap.dedent(
+            """
+            from aleff import Handler, Resume, create_handler, effect
+
+            choose = effect("choose")
+            handler = create_handler(choose)
+
+            @handler.on(choose)
+            def handle_choose(k):
+                return k(1) + k(2)
+
+            def values():
+                value = choose()
+                yield value
+                yield value + 10
+
+            def run():
+                iterator = values()
+                return [next(iterator), next(iterator)]
+
+            assert handler(run) == [1, 11, 2, 12]
+            """
+        )
+
+        result = subprocess.run([sys.executable, "-c", code], text=True, capture_output=True)
+
+        assert result.returncode == 0, result.stderr
 
     def test_resume_twice(self):
         """k can be called twice, each resuming from the same point."""
@@ -764,6 +796,27 @@ class TestMultiShotAsync:
         assert await h(run) == [(1, "KeyError", "ValueError"), (2, "KeyError", "ValueError")]
 
     @pytest.mark.asyncio
+    async def test_inner_handled_exception_does_not_leak_to_outer_coroutine(self):
+        choose: Effect[[], int] = effect("choose")
+        h: AsyncHandler[list[tuple[int, BaseException | None]]] = create_async_handler(choose)
+
+        @h.on(choose)
+        async def _choose(k: ResumeAsync[int, list[tuple[int, BaseException | None]]]):
+            return await k(1) + await k(2)
+
+        async def inner() -> int:
+            try:
+                raise KeyError("inner")
+            except KeyError:
+                return choose()
+
+        async def run() -> list[tuple[int, BaseException | None]]:
+            value = await inner()
+            return [(value, sys.exception())]
+
+        assert await h(run) == [(1, None), (2, None)]
+
+    @pytest.mark.asyncio
     async def test_nested_coroutine_inherits_outer_handled_exception(self):
         """A restored inner coroutine sees an exception handled by its awaiter."""
         choose: Effect[[], int] = effect("choose")
@@ -816,6 +869,80 @@ class TestMultiShotAsync:
                 return [(value, inner_exception, type(exc).__name__)]
 
         assert await h(run) == [(1, "KeyError", "ValueError"), (2, "KeyError", "ValueError")]
+
+    @pytest.mark.asyncio
+    async def test_generator_based_coroutine_returns_after_effect_per_shot(self):
+        choose: Effect[[], int] = effect("choose")
+        h: AsyncHandler[list[int]] = create_async_handler(choose)
+
+        @h.on(choose)
+        async def _choose(k: ResumeAsync[int, list[int]]):
+            return await k(1) + await k(2)
+
+        @types.coroutine
+        def inner():
+            value = choose()
+            if False:
+                yield None
+            return value
+
+        async def run() -> list[int]:
+            return [await inner()]
+
+        assert await h(run) == [1, 2]
+
+    @pytest.mark.asyncio
+    async def test_generator_based_coroutine_bare_yield_after_effect_per_shot(self):
+        choose: Effect[[], int] = effect("choose")
+        h: AsyncHandler[list[int]] = create_async_handler(choose)
+
+        @h.on(choose)
+        async def _choose(k: ResumeAsync[int, list[int]]):
+            return await k(1) + await k(2)
+
+        @types.coroutine
+        def inner():
+            value = choose()
+            yield None
+            return value
+
+        async def run() -> list[int]:
+            return [await inner()]
+
+        assert await h(run) == [1, 2]
+
+    def test_async_generator_frame_is_restored_with_async_generator_ownership(self):
+        code = textwrap.dedent(
+            """
+            import asyncio
+            from aleff import create_async_handler, effect
+
+            choose = effect("choose")
+            handler = create_async_handler(choose)
+
+            @handler.on(choose)
+            async def handle_choose(k):
+                return await k(1) + await k(2)
+
+            async def values():
+                value = choose()
+                yield value
+                yield value + 10
+
+            async def run():
+                iterator = values()
+                return [await anext(iterator), await anext(iterator)]
+
+            async def main():
+                assert await handler(run) == [1, 11, 2, 12]
+
+            asyncio.run(main())
+            """
+        )
+
+        result = subprocess.run([sys.executable, "-c", code], text=True, capture_output=True)
+
+        assert result.returncode == 0, result.stderr
 
     @pytest.mark.asyncio
     async def test_async_caller_preserves_implicit_exception_chaining(self):

--- a/uv.lock
+++ b/uv.lock
@@ -1,11 +1,9 @@
 version = 1
 revision = 3
-requires-python = ">=3.12"
+requires-python = ">=3.12, <3.15"
 resolution-markers = [
-    "python_full_version >= '3.14.4' and sys_platform == 'win32'",
-    "python_full_version >= '3.14' and python_full_version < '3.14.4' and sys_platform == 'win32'",
-    "python_full_version >= '3.14.4' and sys_platform != 'win32'",
-    "python_full_version >= '3.14' and python_full_version < '3.14.4' and sys_platform != 'win32'",
+    "python_full_version >= '3.14.4'",
+    "python_full_version >= '3.14' and python_full_version < '3.14.4'",
     "python_full_version < '3.14'",
 ]
 
@@ -125,7 +123,7 @@ name = "cffi"
 version = "2.0.0"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "pycparser", marker = "(python_full_version < '3.14' and implementation_name != 'PyPy') or (implementation_name != 'PyPy' and sys_platform != 'win32')" },
+    { name = "pycparser", marker = "implementation_name != 'PyPy'" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/eb/56/b1ba7935a17738ae8453301356628e8147c79dbb825bcbc73dc7401f9846/cffi-2.0.0.tar.gz", hash = "sha256:44d1b5909021139fe36001ae048dbdde8214afa20200eda0f64c068cac5d5529", size = 523588, upload-time = "2025-09-08T23:24:04.541Z" }
 wheels = [
@@ -264,7 +262,7 @@ name = "cryptography"
 version = "46.0.7"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "cffi", marker = "(python_full_version < '3.14' and platform_python_implementation != 'PyPy') or (platform_python_implementation != 'PyPy' and sys_platform != 'win32')" },
+    { name = "cffi", marker = "platform_python_implementation != 'PyPy'" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/47/93/ac8f3d5ff04d54bc814e961a43ae5b0b146154c89c61b47bb07557679b18/cryptography-46.0.7.tar.gz", hash = "sha256:e4cfd68c5f3e0bfdad0d38e023239b96a2fe84146481852dffbcca442c245aa5", size = 750652, upload-time = "2026-04-08T01:57:54.692Z" }
 wheels = [
@@ -320,7 +318,7 @@ name = "gdb-mcp"
 version = "0.1.0"
 source = { git = "https://github.com/hnmr293/gdb-mcp#b383e59482646bc1588a111d6d1003404a276b54" }
 dependencies = [
-    { name = "mcp", extra = ["cli"], marker = "python_full_version < '3.14' or sys_platform != 'win32'" },
+    { name = "mcp", extra = ["cli"] },
 ]
 
 [[package]]
@@ -328,8 +326,7 @@ name = "greenlet"
 version = "3.3.2"
 source = { registry = "https://pypi.org/simple" }
 resolution-markers = [
-    "python_full_version >= '3.14' and python_full_version < '3.14.4' and sys_platform == 'win32'",
-    "python_full_version >= '3.14' and python_full_version < '3.14.4' and sys_platform != 'win32'",
+    "python_full_version >= '3.14' and python_full_version < '3.14.4'",
     "python_full_version < '3.14'",
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/a3/51/1664f6b78fc6ebbd98019a1fd730e83fa78f2db7058f72b1463d3612b8db/greenlet-3.3.2.tar.gz", hash = "sha256:2eaf067fc6d886931c7962e8c6bede15d2f01965560f3359b27c80bde2d151f2", size = 188267, upload-time = "2026-02-20T20:54:15.531Z" }
@@ -376,8 +373,7 @@ name = "greenlet"
 version = "3.5.5"
 source = { registry = "https://pypi.org/simple" }
 resolution-markers = [
-    "python_full_version >= '3.14.4' and sys_platform == 'win32'",
-    "python_full_version >= '3.14.4' and sys_platform != 'win32'",
+    "python_full_version >= '3.14.4'",
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/0b/d8/7cc97c142388aef03f622e001c572c4f84e9252a439549d483f555771970/greenlet-3.5.5.tar.gz", hash = "sha256:adb4bae02e91a8e863e48b177e4014bdcac8a6b5e047ea1df687a61534b85e6c", size = 207585, upload-time = "2026-08-10T15:09:36.136Z" }
 wheels = [
@@ -420,26 +416,6 @@ wheels = [
     { url = "https://files.pythonhosted.org/packages/a3/e9/b88bbf5b29970cb84172dc2c32aa3e5e579ceb94c808e81c826454138850/greenlet-3.5.5-cp314-cp314t-musllinux_1_2_aarch64.whl", hash = "sha256:d246c0db9a2513cd45f019ba178ea4d4d4705bd210ee465e2c15d76a1ab13874", size = 1637320, upload-time = "2026-08-10T14:15:09.317Z" },
     { url = "https://files.pythonhosted.org/packages/6d/8c/7631ed29cc6f0392f11830076e172ce4885e70b0bc2c1bce1731176d4b4e/greenlet-3.5.5-cp314-cp314t-musllinux_1_2_x86_64.whl", hash = "sha256:72507285b5caa1d17904a3f7c322ca780823a54170a0e04ec3f37bcc60d4db71", size = 1697412, upload-time = "2026-08-10T13:40:34.924Z" },
     { url = "https://files.pythonhosted.org/packages/da/0f/f7dd935f9c4cb1be49098770587f54d8a78518e55c89bce86c4fb4109057/greenlet-3.5.5-cp314-cp314t-win_amd64.whl", hash = "sha256:7805655781fb8f28a55d05fe57ed61f5f10f1892fb587673e3bb5264f28041f0", size = 331514, upload-time = "2026-08-10T13:29:20.611Z" },
-    { url = "https://files.pythonhosted.org/packages/b7/e5/681b01f8fbc1b55232822f99e8f8afeb78a55a7c76a7bf9dbdc7ccb03a6d/greenlet-3.5.5-cp315-cp315-macosx_11_0_universal2.whl", hash = "sha256:c0db80fcd5b8aece93f66c64f78a786bbb6b96c5fe63ef5a5a4581ecf8bab206", size = 295975, upload-time = "2026-08-10T13:28:45.985Z" },
-    { url = "https://files.pythonhosted.org/packages/11/f2/69b488cd9e7267bf4b0fe8cdebf25d8d6df680d21bdf41150d23e23d6652/greenlet-3.5.5-cp315-cp315-manylinux_2_24_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:6b241c32f912ada659808d68e308c568baf577eebf757d15471472de0c18cfad", size = 666823, upload-time = "2026-08-10T14:14:40.222Z" },
-    { url = "https://files.pythonhosted.org/packages/84/d4/d5bc2fdebbdda0c94555925ba79948b8395d75a7f6a36cc85dce5bab9f11/greenlet-3.5.5-cp315-cp315-manylinux_2_24_ppc64le.manylinux_2_28_ppc64le.whl", hash = "sha256:ef6a08349401d8eaf3cb12688ac8557de95788556b8631ef17555a4a173022c0", size = 677613, upload-time = "2026-08-10T14:27:31.543Z" },
-    { url = "https://files.pythonhosted.org/packages/65/53/4e13642efc4d7ad6554ecb2242a5be42666b2e1a067323e88dfc0124a04b/greenlet-3.5.5-cp315-cp315-manylinux_2_24_s390x.manylinux_2_28_s390x.whl", hash = "sha256:37faa97daccb6d9f4c2141ce3118d023c3c5506864a7d8bdf726f665018c1f76", size = 681436, upload-time = "2026-08-10T14:30:14.839Z" },
-    { url = "https://files.pythonhosted.org/packages/bd/93/542d8a3a90f3b35c6ad8bf7e56a03010287f2cafa289a5b7985b5207db39/greenlet-3.5.5-cp315-cp315-manylinux_2_24_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:f2e3d061b8e13aec2f0441689b3c71b244a20e5d274a52cb0f7e31bd1d139552", size = 675930, upload-time = "2026-08-10T13:40:54.205Z" },
-    { url = "https://files.pythonhosted.org/packages/cd/32/188447c9a468d6977d2989397226b0c6b65ab6f4cf943f931643328512fc/greenlet-3.5.5-cp315-cp315-manylinux_2_39_riscv64.whl", hash = "sha256:b18007dc2473a7942fd157366b55f01da6fed7ce85318591005b419e0a439474", size = 487404, upload-time = "2026-08-10T14:30:08.903Z" },
-    { url = "https://files.pythonhosted.org/packages/52/b5/89c9f2e8460d71101037d47a1feed11928615a5edd42370be290e0657eeb/greenlet-3.5.5-cp315-cp315-musllinux_1_2_aarch64.whl", hash = "sha256:9ab5f5b93655e77fe0d6c2dfd22b5eac751bb1f876d8ec21761b7c1fb9266007", size = 1633878, upload-time = "2026-08-10T14:15:10.693Z" },
-    { url = "https://files.pythonhosted.org/packages/b8/60/297de93f3b02ac78a5e04d32bb8bbe3080f4a73d8ed95016561463b70618/greenlet-3.5.5-cp315-cp315-musllinux_1_2_x86_64.whl", hash = "sha256:f0e5a21bd4452a88cf032fc43c4a5b307ab1380eacb63b5988f9c0317885e773", size = 1696597, upload-time = "2026-08-10T13:40:36.252Z" },
-    { url = "https://files.pythonhosted.org/packages/18/25/54c6eaff4f337fb670215e89eb2d00d9499487b658e709d4b477be4a342e/greenlet-3.5.5-cp315-cp315-win_amd64.whl", hash = "sha256:469dbb0a78625642f4a626cfd0c6e8bccc0385b5e49189b6308bbe849ec88a8e", size = 327700, upload-time = "2026-08-10T13:28:06.752Z" },
-    { url = "https://files.pythonhosted.org/packages/67/67/857e88a36301caa0e029870132c2478bd55d896630321432afab03a3115f/greenlet-3.5.5-cp315-cp315-win_arm64.whl", hash = "sha256:2d57406c3efd32d7a81e17a674314e8bd00792cdab49ea3228a49aa1bfb2e769", size = 311750, upload-time = "2026-08-10T13:34:08.815Z" },
-    { url = "https://files.pythonhosted.org/packages/10/e2/3144c0a116067ac1e30457b0139a94d60d1d36a86e015de68e9ac87cb3bc/greenlet-3.5.5-cp315-cp315t-macosx_11_0_universal2.whl", hash = "sha256:68184dfcf50ccaa8e864770fe0633a7e27250ea9329f8192ef47ee9ecfd78e1c", size = 306387, upload-time = "2026-08-10T13:27:00.897Z" },
-    { url = "https://files.pythonhosted.org/packages/5c/a1/cb4223a7e9b9f43b8807e8eb212358bfe2dfaa174a9ea2889eb1714dcba2/greenlet-3.5.5-cp315-cp315t-manylinux_2_24_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:9ec0dc0e59dc9c61af5c47348365ccbbd7addfafe0a93b00336ff3da2907bdc6", size = 676472, upload-time = "2026-08-10T14:14:41.417Z" },
-    { url = "https://files.pythonhosted.org/packages/9e/cd/a154b4498e5d8f12ada291cfb3b8d596eadde2177f5bf09a9be699d2a446/greenlet-3.5.5-cp315-cp315t-manylinux_2_24_ppc64le.manylinux_2_28_ppc64le.whl", hash = "sha256:e604f58e35833fc46ef20302bcb314dddbfd3fcf33a4f936216d51dd678d63ae", size = 684238, upload-time = "2026-08-10T14:27:32.946Z" },
-    { url = "https://files.pythonhosted.org/packages/ce/f4/e450a68a152f819491d8c7df6a8254e761d87e6a78759268961f8c5bd4dd/greenlet-3.5.5-cp315-cp315t-manylinux_2_24_s390x.manylinux_2_28_s390x.whl", hash = "sha256:2888a3a38bc5ee5bb6c438372197152e815837e4fab7ed7a1f86ef18ffd58ad1", size = 686022, upload-time = "2026-08-10T14:30:15.96Z" },
-    { url = "https://files.pythonhosted.org/packages/bf/bb/b0031d260c2968a3c87deebc51d80c64e499377f993aafe06ee3b7488cc2/greenlet-3.5.5-cp315-cp315t-manylinux_2_24_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:40239b5384f96da3963585cc6d7eaa9b56f8ae67e8d92cc82dd9e202fc847de3", size = 681246, upload-time = "2026-08-10T13:40:55.402Z" },
-    { url = "https://files.pythonhosted.org/packages/18/23/17e63d6bf3b9c9b9dbea981b7f643a71f79603bdfb4f1c3a9cf353e22aed/greenlet-3.5.5-cp315-cp315t-manylinux_2_39_riscv64.whl", hash = "sha256:1e8d9391fe77f15649589a907cef972dbbd6352ef7ff7dc0492f658c0c26495f", size = 516951, upload-time = "2026-08-10T14:30:10.907Z" },
-    { url = "https://files.pythonhosted.org/packages/9a/07/da554b71ab88e649da146e1065d86a48a5c5d92e50ab74ef41b504aa7f56/greenlet-3.5.5-cp315-cp315t-musllinux_1_2_aarch64.whl", hash = "sha256:a1eaccf5c3a1d3e46dead602c72e6836731e8e245c9de6a27764567b6b62d4c0", size = 1642735, upload-time = "2026-08-10T14:15:11.92Z" },
-    { url = "https://files.pythonhosted.org/packages/78/76/26a3782a051677668af9d92beaa47cd87ba9dd5072f762961144a03dd4c6/greenlet-3.5.5-cp315-cp315t-musllinux_1_2_x86_64.whl", hash = "sha256:19e4e026fe20691f333b8eb1a3bc9625eceba8c3f9d62ec5a6f8581afbc6b5a5", size = 1700925, upload-time = "2026-08-10T13:40:37.656Z" },
-    { url = "https://files.pythonhosted.org/packages/28/d9/fe7baf4190c2ae71f267efb9de21b3172bb35bc0ed1ef53dd6027d658e33/greenlet-3.5.5-cp315-cp315t-win_amd64.whl", hash = "sha256:712aee154f648bde84634654bb38bb78c69ac640c37a45c9effed800735049d8", size = 331829, upload-time = "2026-08-10T13:26:48.851Z" },
-    { url = "https://files.pythonhosted.org/packages/df/af/419a4e383bd600858a9b67e9b280a60fdc383ee3f2fe5b6c0c1ef04e74d1/greenlet-3.5.5-cp315-cp315t-win_arm64.whl", hash = "sha256:7f049911ee81a16a03c33d5450d8d5867d27f596ca5fb201b86f4524e874468b", size = 315093, upload-time = "2026-08-10T13:29:34.949Z" },
 ]
 
 [[package]]
@@ -456,8 +432,8 @@ name = "httpcore"
 version = "1.0.9"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "certifi", marker = "python_full_version < '3.14' or sys_platform != 'win32'" },
-    { name = "h11", marker = "python_full_version < '3.14' or sys_platform != 'win32'" },
+    { name = "certifi" },
+    { name = "h11" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/06/94/82699a10bca87a5556c9c59b5963f2d039dbd239f25bc2a63907a05a14cb/httpcore-1.0.9.tar.gz", hash = "sha256:6e34463af53fd2ab5d807f399a9b45ea31c3dfa2276f15a2c3f00afff6e176e8", size = 85484, upload-time = "2025-04-24T22:06:22.219Z" }
 wheels = [
@@ -469,10 +445,10 @@ name = "httpx"
 version = "0.28.1"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "anyio", marker = "python_full_version < '3.14' or sys_platform != 'win32'" },
-    { name = "certifi", marker = "python_full_version < '3.14' or sys_platform != 'win32'" },
-    { name = "httpcore", marker = "python_full_version < '3.14' or sys_platform != 'win32'" },
-    { name = "idna", marker = "python_full_version < '3.14' or sys_platform != 'win32'" },
+    { name = "anyio" },
+    { name = "certifi" },
+    { name = "httpcore" },
+    { name = "idna" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/b1/df/48c586a5fe32a0f01324ee087459e112ebb7224f646c0b5023f5e79e9956/httpx-0.28.1.tar.gz", hash = "sha256:75e98c5f16b0f35b567856f597f06ff2270a374470a5c2392242528e3e3e42fc", size = 141406, upload-time = "2024-12-06T15:37:23.222Z" }
 wheels = [
@@ -532,10 +508,10 @@ name = "jsonschema"
 version = "4.26.0"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "attrs", marker = "python_full_version < '3.14' or sys_platform != 'win32'" },
-    { name = "jsonschema-specifications", marker = "python_full_version < '3.14' or sys_platform != 'win32'" },
-    { name = "referencing", marker = "python_full_version < '3.14' or sys_platform != 'win32'" },
-    { name = "rpds-py", marker = "python_full_version < '3.14' or sys_platform != 'win32'" },
+    { name = "attrs" },
+    { name = "jsonschema-specifications" },
+    { name = "referencing" },
+    { name = "rpds-py" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/b3/fc/e067678238fa451312d4c62bf6e6cf5ec56375422aee02f9cb5f909b3047/jsonschema-4.26.0.tar.gz", hash = "sha256:0c26707e2efad8aa1bfc5b7ce170f3fccc2e4918ff85989ba9ffa9facb2be326", size = 366583, upload-time = "2026-01-07T13:41:07.246Z" }
 wheels = [
@@ -547,7 +523,7 @@ name = "jsonschema-specifications"
 version = "2025.9.1"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "referencing", marker = "python_full_version < '3.14' or sys_platform != 'win32'" },
+    { name = "referencing" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/19/74/a633ee74eb36c44aa6d1095e7cc5569bebf04342ee146178e2d36600708b/jsonschema_specifications-2025.9.1.tar.gz", hash = "sha256:b540987f239e745613c7a9176f3edb72b832a4ac465cf02712288397832b5e8d", size = 32855, upload-time = "2025-09-08T01:34:59.186Z" }
 wheels = [
@@ -634,19 +610,19 @@ name = "mcp"
 version = "1.27.0"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "anyio", marker = "python_full_version < '3.14' or sys_platform != 'win32'" },
-    { name = "httpx", marker = "python_full_version < '3.14' or sys_platform != 'win32'" },
-    { name = "httpx-sse", marker = "python_full_version < '3.14' or sys_platform != 'win32'" },
-    { name = "jsonschema", marker = "python_full_version < '3.14' or sys_platform != 'win32'" },
-    { name = "pydantic", marker = "python_full_version < '3.14' or sys_platform != 'win32'" },
-    { name = "pydantic-settings", marker = "python_full_version < '3.14' or sys_platform != 'win32'" },
-    { name = "pyjwt", extra = ["crypto"], marker = "python_full_version < '3.14' or sys_platform != 'win32'" },
-    { name = "python-multipart", marker = "python_full_version < '3.14' or sys_platform != 'win32'" },
-    { name = "sse-starlette", marker = "python_full_version < '3.14' or sys_platform != 'win32'" },
-    { name = "starlette", marker = "python_full_version < '3.14' or sys_platform != 'win32'" },
-    { name = "typing-extensions", marker = "python_full_version < '3.14' or sys_platform != 'win32'" },
-    { name = "typing-inspection", marker = "python_full_version < '3.14' or sys_platform != 'win32'" },
-    { name = "uvicorn", marker = "(python_full_version < '3.14' and sys_platform == 'win32') or (sys_platform != 'emscripten' and sys_platform != 'win32')" },
+    { name = "anyio" },
+    { name = "httpx" },
+    { name = "httpx-sse" },
+    { name = "jsonschema" },
+    { name = "pydantic" },
+    { name = "pydantic-settings" },
+    { name = "pyjwt", extra = ["crypto"] },
+    { name = "python-multipart" },
+    { name = "sse-starlette" },
+    { name = "starlette" },
+    { name = "typing-extensions" },
+    { name = "typing-inspection" },
+    { name = "uvicorn", marker = "sys_platform != 'emscripten'" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/8b/eb/c0cfc62075dc6e1ec1c64d352ae09ac051d9334311ed226f1f425312848a/mcp-1.27.0.tar.gz", hash = "sha256:d3dc35a7eec0d458c1da4976a48f982097ddaab87e278c5511d5a4a56e852b83", size = 607509, upload-time = "2026-04-02T14:48:08.88Z" }
 wheels = [
@@ -655,8 +631,8 @@ wheels = [
 
 [package.optional-dependencies]
 cli = [
-    { name = "python-dotenv", marker = "python_full_version < '3.14' or sys_platform != 'win32'" },
-    { name = "typer", marker = "python_full_version < '3.14' or sys_platform != 'win32'" },
+    { name = "python-dotenv" },
+    { name = "typer" },
 ]
 
 [[package]]
@@ -738,10 +714,10 @@ name = "pydantic"
 version = "2.12.5"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "annotated-types", marker = "python_full_version < '3.14' or sys_platform != 'win32'" },
-    { name = "pydantic-core", marker = "python_full_version < '3.14' or sys_platform != 'win32'" },
-    { name = "typing-extensions", marker = "python_full_version < '3.14' or sys_platform != 'win32'" },
-    { name = "typing-inspection", marker = "python_full_version < '3.14' or sys_platform != 'win32'" },
+    { name = "annotated-types" },
+    { name = "pydantic-core" },
+    { name = "typing-extensions" },
+    { name = "typing-inspection" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/69/44/36f1a6e523abc58ae5f928898e4aca2e0ea509b5aa6f6f392a5d882be928/pydantic-2.12.5.tar.gz", hash = "sha256:4d351024c75c0f085a9febbb665ce8c0c6ec5d30e903bdb6394b7ede26aebb49", size = 821591, upload-time = "2025-11-26T15:11:46.471Z" }
 wheels = [
@@ -753,7 +729,7 @@ name = "pydantic-core"
 version = "2.41.5"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "typing-extensions", marker = "python_full_version < '3.14' or sys_platform != 'win32'" },
+    { name = "typing-extensions" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/71/70/23b021c950c2addd24ec408e9ab05d59b035b39d97cdc1130e1bce647bb6/pydantic_core-2.41.5.tar.gz", hash = "sha256:08daa51ea16ad373ffd5e7606252cc32f07bc72b28284b6bc9c6df804816476e", size = 460952, upload-time = "2025-11-04T13:43:49.098Z" }
 wheels = [
@@ -812,9 +788,9 @@ name = "pydantic-settings"
 version = "2.13.1"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "pydantic", marker = "python_full_version < '3.14' or sys_platform != 'win32'" },
-    { name = "python-dotenv", marker = "python_full_version < '3.14' or sys_platform != 'win32'" },
-    { name = "typing-inspection", marker = "python_full_version < '3.14' or sys_platform != 'win32'" },
+    { name = "pydantic" },
+    { name = "python-dotenv" },
+    { name = "typing-inspection" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/52/6d/fffca34caecc4a3f97bda81b2098da5e8ab7efc9a66e819074a11955d87e/pydantic_settings-2.13.1.tar.gz", hash = "sha256:b4c11847b15237fb0171e1462bf540e294affb9b86db4d9aa5c01730bdbe4025", size = 223826, upload-time = "2026-02-19T13:45:08.055Z" }
 wheels = [
@@ -841,7 +817,7 @@ wheels = [
 
 [package.optional-dependencies]
 crypto = [
-    { name = "cryptography", marker = "python_full_version < '3.14' or sys_platform != 'win32'" },
+    { name = "cryptography" },
 ]
 
 [[package]]
@@ -955,8 +931,8 @@ name = "referencing"
 version = "0.37.0"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "attrs", marker = "python_full_version < '3.14' or sys_platform != 'win32'" },
-    { name = "rpds-py", marker = "python_full_version < '3.14' or sys_platform != 'win32'" },
+    { name = "attrs" },
+    { name = "rpds-py" },
     { name = "typing-extensions", marker = "python_full_version < '3.13'" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/22/f5/df4e9027acead3ecc63e50fe1e36aca1523e1719559c499951bb4b53188f/referencing-0.37.0.tar.gz", hash = "sha256:44aefc3142c5b842538163acb373e24cce6632bd54bdb01b21ad5863489f50d8", size = 78036, upload-time = "2025-10-13T15:30:48.871Z" }
@@ -984,8 +960,8 @@ name = "rich"
 version = "14.3.3"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "markdown-it-py", marker = "python_full_version < '3.14' or sys_platform != 'win32'" },
-    { name = "pygments", marker = "python_full_version < '3.14' or sys_platform != 'win32'" },
+    { name = "markdown-it-py" },
+    { name = "pygments" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/b3/c6/f3b320c27991c46f43ee9d856302c70dc2d0fb2dba4842ff739d5f46b393/rich-14.3.3.tar.gz", hash = "sha256:b8daa0b9e4eef54dd8cf7c86c03713f53241884e814f4e2f5fb342fe520f639b", size = 230582, upload-time = "2026-02-19T17:23:12.474Z" }
 wheels = [
@@ -1254,8 +1230,8 @@ name = "sse-starlette"
 version = "3.3.4"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "anyio", marker = "python_full_version < '3.14' or sys_platform != 'win32'" },
-    { name = "starlette", marker = "python_full_version < '3.14' or sys_platform != 'win32'" },
+    { name = "anyio" },
+    { name = "starlette" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/26/8c/f9290339ef6d79badbc010f067cd769d6601ec11a57d78569c683fb4dd87/sse_starlette-3.3.4.tar.gz", hash = "sha256:aaf92fc067af8a5427192895ac028e947b484ac01edbc3caf00e7e7137c7bef1", size = 32427, upload-time = "2026-03-29T09:00:23.307Z" }
 wheels = [
@@ -1280,10 +1256,10 @@ name = "typer"
 version = "0.24.1"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "annotated-doc", marker = "python_full_version < '3.14' or sys_platform != 'win32'" },
-    { name = "click", marker = "python_full_version < '3.14' or sys_platform != 'win32'" },
-    { name = "rich", marker = "python_full_version < '3.14' or sys_platform != 'win32'" },
-    { name = "shellingham", marker = "python_full_version < '3.14' or sys_platform != 'win32'" },
+    { name = "annotated-doc" },
+    { name = "click" },
+    { name = "rich" },
+    { name = "shellingham" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/f5/24/cb09efec5cc954f7f9b930bf8279447d24618bb6758d4f6adf2574c41780/typer-0.24.1.tar.gz", hash = "sha256:e39b4732d65fbdcde189ae76cf7cd48aeae72919dea1fdfc16593be016256b45", size = 118613, upload-time = "2026-02-21T16:54:40.609Z" }
 wheels = [
@@ -1304,7 +1280,7 @@ name = "typing-inspection"
 version = "0.4.2"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "typing-extensions", marker = "python_full_version < '3.14' or sys_platform != 'win32'" },
+    { name = "typing-extensions" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/55/e3/70399cb7dd41c10ac53367ae42139cf4b1ca5f36bb3dc6c9d33acdb43655/typing_inspection-0.4.2.tar.gz", hash = "sha256:ba561c48a67c5958007083d386c3295464928b01faa735ab8547c5692e87f464", size = 75949, upload-time = "2025-10-01T02:14:41.687Z" }
 wheels = [


### PR DESCRIPTION
## Summary

- restore native coroutine and generator-backed async frames across repeated multi-shot resumes
- preserve generator ownership and handled exception state while rebuilding continuation frames
- analyze and validate SEND stack metadata in C across CPython 3.12–3.14, including async generators and extended jump arguments
- reject unsupported synchronous generator restoration with an explicit error instead of unsafe frame restoration

## Testing

- `./run_tests.sh`
  - Python 3.12: 521 passed, 3 skipped; examples 10/10
  - Python 3.13: 521 passed, 3 skipped; examples 10/10
  - Python 3.14: 521 passed, 3 skipped; examples 10/10
  - Python 3.14t: 524 passed; examples 10/10
- `uv run pyright`
- `uv run ruff check .`
- `uv run ruff format --check .`
- `git diff --check origin/dev...HEAD`

## Commits

- `a07cedd` fix: restore async multi-shot continuations #40
- `f2b68c3` wip: preserve generator ownership in continuations #40
- `ebdcf66` fix: safely restore generator-backed async continuations #40
- `e8a9d6a` test: cover consecutive extended jump arguments #40

Closes #40
