### PR TITLE
docs: prohibit effects in unsupported callbacks

### DIFF
--- a/docs/source/api/effects.rst
+++ b/docs/source/api/effects.rst
@@ -1,6 +1,25 @@
 Effects & Handlers
 ==================
 
+Prohibited callback contexts
+----------------------------
+
+.. warning::
+
+   Effects must not be performed, and :class:`Resume` and
+   :class:`ResumeAsync` continuations must not be invoked, from any of the
+   following callback contexts:
+
+   * audit hooks;
+   * tracing, profiling, or ``sys.monitoring`` callbacks;
+   * signal handlers;
+   * weak-reference callbacks;
+   * garbage-collector callbacks;
+   * ``__del__`` methods or other finalizers;
+   * ``atexit`` callbacks; or
+   * GUI callbacks, event-loop callbacks, or callbacks running on another
+     thread.
+
 def effect
 ----------
 


### PR DESCRIPTION
## Summary

- document callback contexts where effects must not be performed
- document callback contexts where continuations must not be invoked
- track the remaining C-boundary work in #55, #56, #57, and #58

## Testing

- `git diff --check`
- `uv run sphinx-build -W -b html docs/source /tmp/aleff-docs-pr-54`

## Commits

- `49f7f03` docs: prohibit effects in unsupported callbacks

Closes #54
