### PR TITLE
Fix wheel test dependency installation

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -87,9 +87,6 @@ test-command = "pytest {project}/tests -q"
 test-requires = [
     "pytest",
     "pytest-asyncio",
-    "greenlet>=3.3.2; python_version < '3.14'",
-    "greenlet>=3.3.2,<3.4.0; python_full_version >= '3.14' and python_full_version < '3.14.4'",
-    "greenlet>=3.5.5; python_full_version >= '3.14.4'",
 ]
 
 [tool.cibuildwheel.linux]


### PR DESCRIPTION
## Summary

- Remove redundant greenlet requirements from cibuildwheel test dependencies.
- Continue installing greenlet through the package runtime dependencies.
- Prevent cibuildwheel 3.4.1 from splitting marker-bearing requirements before wheel tests.

## Verification

- uv lock --check
- No test suite rerun; the failed release workflow established that wheel installation already installs greenlet before test dependencies.

## Commits

- db8e4e2 fix: remove redundant wheel test dependencies